### PR TITLE
feat(ignore_stdout): option to ignore stdout 

### DIFF
--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -254,6 +254,8 @@ with the following changes:
 
 - `ignore_stderr`: set to `true` by default.
 
+- `ignore_stdout`: set to `false` by default.
+
 - `on_output`: will always return an edit that will replace the current buffer's
   content with formatter output. As a result, other options that depend on
   `on_output`, such as `format`, will not have an effect.

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -6,6 +6,7 @@ local u = require("null-ls.utils")
 local output_formats = {
     raw = "raw", -- receive error_output and output directly
     none = nil, -- same as raw but will not send error output
+    ignore = "ignore",
     line = "line", -- call handler once per line of output
     json = "json", -- send processed json output to handler
     json_raw = "json_raw", -- attempt to process json, but send errors to handler
@@ -144,7 +145,7 @@ return function(opts)
                 function(a)
                     return not a or vim.tbl_contains(vim.tbl_values(output_formats), a)
                 end,
-                "raw, line, json, or json_raw",
+                "raw, ignore, line, json, or json_raw",
             },
             from_stderr = { from_stderr, "boolean", true },
             ignore_stderr = { ignore_stderr, "boolean", true },
@@ -220,8 +221,13 @@ return function(opts)
                         error("error in generator output: " .. error_output)
                     end
 
-                    params.output = params.output or output
-                    opts._last_output = output or ""
+                    if format == output_formats.ignore then
+                        params.output = nil
+                        params._last_output = ""
+                    else
+                        params.output = params.output or output
+                        opts._last_output = output or ""
+                    end
 
                     if use_cache then
                         s.set_cache(params.bufnr, command, output)

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -207,7 +207,6 @@ return function(opts)
                 log:trace("error output: " .. (error_output or "nil"))
                 log:trace("output: " .. (output or "nil"))
 
-                print(vim.inspect(opts))
                 if ignore_stdout then
                     if error_output then
                         log:trace("ignoring stdout due to generator options")

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -6,7 +6,6 @@ local u = require("null-ls.utils")
 local output_formats = {
     raw = "raw", -- receive error_output and output directly
     none = nil, -- same as raw but will not send error output
-    ignore = "ignore",
     line = "line", -- call handler once per line of output
     json = "json", -- send processed json output to handler
     json_raw = "json_raw", -- attempt to process json, but send errors to handler
@@ -102,13 +101,14 @@ local line_output_wrapper = function(params, done, on_output)
 end
 
 return function(opts)
-    local command, args, env, on_output, format, ignore_stderr, from_stderr, to_stdin, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition, cwd, dynamic_command, multiple_files, temp_dir, prepend_extra_args =
+    local command, args, env, on_output, format, ignore_stderr, ignore_stdout, from_stderr, to_stdin, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition, cwd, dynamic_command, multiple_files, temp_dir, prepend_extra_args =
         opts.command,
         opts.args,
         opts.env,
         opts.on_output,
         opts.format,
         opts.ignore_stderr,
+        opts.ignore_stdout,
         opts.from_stderr,
         opts.to_stdin,
         opts.check_exit_code,
@@ -145,10 +145,11 @@ return function(opts)
                 function(a)
                     return not a or vim.tbl_contains(vim.tbl_values(output_formats), a)
                 end,
-                "raw, ignore, line, json, or json_raw",
+                "raw, line, json, or json_raw",
             },
             from_stderr = { from_stderr, "boolean", true },
             ignore_stderr = { ignore_stderr, "boolean", true },
+            ignore_stdout = { ignore_stdout, "boolean", true },
             to_stdin = { to_stdin, "boolean", true },
             check_exit_code = { check_exit_code, "function", true },
             timeout = { timeout, "number", true },
@@ -206,6 +207,13 @@ return function(opts)
                 log:trace("error output: " .. (error_output or "nil"))
                 log:trace("output: " .. (output or "nil"))
 
+                print(vim.inspect(opts))
+                if ignore_stdout then
+                    if error_output then
+                        log:trace("ignoring stdout due to generator options")
+                    end
+                    output = nil
+                end
                 if ignore_stderr then
                     if error_output then
                         log:trace("ignoring stderr due to generator options")
@@ -221,13 +229,8 @@ return function(opts)
                         error("error in generator output: " .. error_output)
                     end
 
-                    if format == output_formats.ignore then
-                        params.output = nil
-                        params._last_output = ""
-                    else
-                        params.output = params.output or output
-                        opts._last_output = output or ""
-                    end
+                    params.output = params.output or output
+                    opts._last_output = output or ""
 
                     if use_cache then
                         s.set_cache(params.bufnr, command, output)

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -36,6 +36,7 @@ local function make_builtin(opts)
         diagnostics_postprocess = opts.diagnostics_postprocess,
         dynamic_command = opts.dynamic_command,
         ignore_stderr = opts.ignore_stderr,
+        ignore_stdout = opts.ignore_stdout,
         runtime_condition = opts.runtime_condition,
         timeout = opts.timeout,
         to_temp_file = opts.to_temp_file,


### PR DESCRIPTION
Some  formatters don't actually return the code and just modify $FILENAME directly, for example `biome`.

With this option we can now avoid using a tempfile.

I'll have a PR for biome if this gets accepted.

Right now I'm using:

```lua
nls.builtins.formatting.biome.with({
	args = {
		'check',
		'--apply',
		'--formatter-enabled=true',
		'--organize-imports-enabled=true',
		'--skip-errors',
		'$FILENAME',
	},
	ignore_stdout = true,
	ignore_stderr = true,
	to_temp_file = false,
}),
```