### PR TITLE
feat: add support for templ formatting built-in

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -4861,6 +4861,23 @@ local sources = { null_ls.builtins.formatting.swift_format }
 - Command: `swift-format`
 - Args: `{}`
 
+### [templ](https://templ.guide/commands-and-tools/cli/#formatting-templ-files)
+
+A Go HTML template engine
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.templ }
+```
+
+#### Defaults
+
+- Filetypes: `{ "templ" }`
+- Method: `formatting`
+- Command: `templ`
+- Args: `{ "fmt" }`
+
 ### [taplo](https://taplo.tamasfe.dev/)
 
 A versatile, feature-rich TOML toolkit.

--- a/lua/null-ls/builtins/formatting/templ.lua
+++ b/lua/null-ls/builtins/formatting/templ.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "templ",
+    meta = {
+        url = "https://templ.guide/commands-and-tools/cli/#formatting-templ-files",
+        description = "Formats templ template files.",
+    },
+    method = FORMATTING,
+    filetypes = { "templ" },
+    generator_opts = {
+        command = "templ",
+        args = { "fmt" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Like in the PR https://github.com/stevearc/conform.nvim/pull/73 of conform.nvim made by @zbindenren.

I would also like to add support for the templ formatter in `none-ls.nvim`.