### PR TITLE
docs: update vale.sh links

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2268,7 +2268,7 @@ local sources = { null_ls.builtins.diagnostics.vale }
 
 #### Notes
 
-- vale does not include a syntax by itself, so you probably need to grab a `vale.ini` (at `~/.vale.ini`) and a StylesPath (somewhere, pointed from `vale.ini`) from [the list of configurations](https://docs.errata.ai/vale/about#open-source-configurations).
+- vale doesn't include a syntax by itself, so you need to [create a `vale.ini`](https://vale.sh/generator)) and download [styles](https://vale.sh/docs/vale-cli/structure/#styles) with `vale sync`.
 
 ### [verilator](https://www.veripool.org/verilator/)
 

--- a/lua/null-ls/builtins/diagnostics/vale.lua
+++ b/lua/null-ls/builtins/diagnostics/vale.lua
@@ -8,10 +8,10 @@ local severities = { error = 1, warning = 2, suggestion = 4 }
 return h.make_builtin({
     name = "vale",
     meta = {
-        url = "https://docs.errata.ai/vale/about",
+        url = "https://vale.sh/",
         description = "Syntax-aware linter for prose built with speed and extensibility in mind.",
         notes = {
-            [[vale does not include a syntax by itself, so you probably need to grab a `vale.ini` (at `~/.vale.ini`) and a StylesPath (somewhere, pointed from `vale.ini`) from [the list of configurations](https://docs.errata.ai/vale/about#open-source-configurations).]],
+            [[vale doesn't include a syntax by itself, so you need to [create a `vale.ini`](https://vale.sh/generator)) and download [styles](https://vale.sh/docs/vale-cli/structure/#styles) with `vale sync`.]],
         },
     },
     method = DIAGNOSTICS,


### PR DESCRIPTION
Update some outdated links for https://vale.sh/

There may have been some updates to `vale` since this diagnostic was written. It generally requires you to run `vale sync` once right after you create your initial `.vale.ini`, to download styles. Is that ok for `none-ls` (I'm not too familiar with how this plugin usually works yet), or should the diagnostic be reworked to auto-call `vale sync` as long as a `.vale.ini` exists?