### PR TITLE
Updates swiftlint builtins to check exit code

### DIFF
--- a/lua/null-ls/builtins/diagnostics/swiftlint.lua
+++ b/lua/null-ls/builtins/diagnostics/swiftlint.lua
@@ -35,6 +35,9 @@ return h.make_builtin({
         to_stdin = true,
         format = "json",
         on_output = handle_swiftlint_output,
+        check_exit_code = function(code)
+            return code <= 2
+        end,
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern("Package.swift", ".git")(params.bufname)
         end),


### PR DESCRIPTION
Swiftlint returns a `2` exit code when it detects errors in your code, I've added a check to account for that. Currently when trying to use it for diagnostics, none-ls assumes it has failed.