### PR TITLE
fix: leptosfmt generator-options

### DIFF
--- a/lua/null-ls/builtins/formatting/leptosfmt.lua
+++ b/lua/null-ls/builtins/formatting/leptosfmt.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = { "rust" },
     generator_opts = {
         command = "leptosfmt",
-        args = { "--quiet=true", "--stdin=true" },
+        args = { "--quiet", "--stdin" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
It seems whenever I tried using leptosfmt using the CLI options that were in the none-ls config, I'd get this error:

```
$ leptosfmt --stdin=true --quiet=true
error: unexpected value 'true' for '--stdin' found; no more were expected

Usage: leptosfmt --stdin [INPUT_PATTERNS]...

For more information, try '--help'.
```

But using `leptosfmt --stdin --quiet` will work fine