### PR TITLE
fix: broken log file path for NullLsLog

### DIFF
--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -51,7 +51,7 @@ end
 ---Retrieves the path of the logfile
 ---@return string path of the logfile
 function log:get_path()
-    return u.path.join(vim.fn.stdpath("cache"), "null-ls.log")
+    return u.path.join(vim.fn.stdpath("cache"), "null-ls")
 end
 
 ---Add a log entry at TRACE level

--- a/test/spec/logger_spec.lua
+++ b/test/spec/logger_spec.lua
@@ -1,0 +1,8 @@
+local logger = require("null-ls.logger")
+
+describe("logger", function()
+    it("get_path should return log file path from cache folder", function()
+        local expected = vim.fn.stdpath("cache") .. "/" .. "null-ls"
+        assert.equals(expected, logger.get_path())
+    end)
+end)


### PR DESCRIPTION
NullLsLog command is currently broken and does nothing.