### PR TITLE
synchronous root dir setting contributes to suboptimal load times

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -209,6 +209,9 @@ local root_dir_async = function(fname, cb)
 end
 ```
 
+For a utility that asynchronously finds a matching file, see
+`utils.root_pattern_async`.
+
 ### should_attach (function, optional)
 
 A user-defined function that controls whether to enable null-ls for a given

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -55,6 +55,7 @@ local defaults = {
     on_init = nil,
     on_exit = nil,
     root_dir = require("null-ls.utils").root_pattern(".null-ls-root", "Makefile", ".git"),
+    root_dir_async = nil,
     should_attach = nil,
     sources = nil,
     temp_dir = nil,
@@ -196,6 +197,17 @@ end
 
 If `root_dir` returns `nil`, the root will resolve to the current working
 directory.
+
+### root_dir_async (function)
+
+Like `root_dir` but also accepts a callback parameter allowing it to be
+asynchronous. Overwrites `root_dir` when present.
+
+```lua
+local root_dir_async = function(fname, cb)
+    cb(fname:match("my-project") and "my-project-root")
+end
+```
 
 ### should_attach (function, optional)
 

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -36,7 +36,13 @@ end
 local get_root_dir = function(bufnr, cb)
     local config = c.get()
     local fname = api.nvim_buf_get_name(bufnr)
-    cb(config.root_dir(fname) or vim.loop.cwd() or ".")
+    if config.root_dir_async then
+        config.root_dir_async(fname, function(found_root_dir)
+            cb(found_root_dir or vim.loop.cwd() or ".")
+        end)
+    else
+        cb(config.root_dir(fname) or vim.loop.cwd() or ".")
+    end
 end
 
 local on_init = function(new_client, initialize_result)

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -70,10 +70,11 @@ end
 
 local M = {}
 
-M.start_client = function(fname)
+---@param root_dir string The root directory of the project.
+M.start_client = function(root_dir)
     local config = {
         name = "null-ls",
-        root_dir = c.get().root_dir(fname) or vim.loop.cwd(),
+        root_dir = root_dir,
         on_init = on_init,
         on_exit = on_exit,
         cmd = require("null-ls.rpc").start, -- pass callback to create rpc client
@@ -110,7 +111,9 @@ M.try_add = function(bufnr)
         return false
     end
 
-    id = id or M.start_client(api.nvim_buf_get_name(bufnr))
+    local fname = api.nvim_buf_get_name(bufnr)
+    local root_dir = c.get().root_dir(fname) or vim.loop.cwd()
+    id = id or M.start_client(root_dir)
     if not id then
         return
     end

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -29,6 +29,16 @@ local should_attach = function(bufnr)
     return false
 end
 
+--- Returns the root directory for the given buffer.
+---
+---@param bufnr number
+---@return string
+local get_root_dir = function(bufnr)
+    local config = c.get()
+    local fname = api.nvim_buf_get_name(bufnr)
+    return config.root_dir(fname) or vim.loop.cwd() or "."
+end
+
 local on_init = function(new_client, initialize_result)
     local capability_is_disabled = function(method)
         -- TODO: extract map to prevent future issues
@@ -111,9 +121,7 @@ M.try_add = function(bufnr)
         return false
     end
 
-    local fname = api.nvim_buf_get_name(bufnr)
-    local root_dir = c.get().root_dir(fname) or vim.loop.cwd()
-    id = id or M.start_client(root_dir)
+    id = id or M.start_client(get_root_dir(bufnr))
     if not id then
         return
     end

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -17,6 +17,7 @@ local defaults = {
     -- format string for vim.notify messages
     notify_format = "[null-ls] %s",
     root_dir = u.root_pattern(".null-ls-root", "Makefile", ".git"),
+    root_dir_async = nil,
     update_in_insert = false,
     -- prevent double setup
     _setup = false,
@@ -25,6 +26,7 @@ local defaults = {
 local config = vim.deepcopy(defaults)
 
 local type_overrides = {
+    root_dir_async = { "function", "nil" },
     on_attach = { "function", "nil" },
     on_init = { "function", "nil" },
     on_exit = { "function", "nil" },

--- a/test/spec/client_spec.lua
+++ b/test/spec/client_spec.lua
@@ -217,6 +217,30 @@ describe("client", function()
             end)
         end)
 
+        it("should use custom root_dir_async", function()
+            local co = coroutine.running()
+            assert(co, "not running inside a coroutine")
+
+            local root_dir = stub.new()
+            root_dir.returns("to-be-ignored")
+            c._set({
+                root_dir_async = function(_, cb)
+                    vim.schedule(function()
+                        cb("mock-root")
+                    end)
+                end,
+                root_dir = root_dir,
+            })
+
+            client.try_add(mock_bufnr, function()
+                coroutine.resume(co)
+            end)
+
+            coroutine.yield()
+            local opts = lsp.start_client.calls[1].refs[1]
+            assert.equals(opts.root_dir, "mock-root")
+        end)
+
         it("should not attach if user-defined should_attach returns false", function()
             local should_attach = stub.new(nil, nil, false)
             c._set({ should_attach = should_attach })

--- a/test/spec/client_spec.lua
+++ b/test/spec/client_spec.lua
@@ -182,17 +182,17 @@ describe("client", function()
             local should_attach = stub.new(nil, nil, true)
             c._set({ should_attach = should_attach })
 
-            local did_attach = client.try_add(mock_bufnr)
-
-            assert.stub(should_attach).was_called_with(mock_bufnr)
-            assert.stub(api.nvim_buf_get_option).was_called_with(mock_bufnr, "buftype")
-            assert.stub(api.nvim_buf_get_option).was_called_with(mock_bufnr, "filetype")
-            assert.stub(api.nvim_buf_get_name).was_called_with(mock_bufnr)
-            assert.stub(sources.get_all).was_called()
-            assert.stub(sources.is_available).was_called_with(mock_sources[1], "")
-            assert.stub(lsp.buf_is_attached).was_called_with(mock_bufnr, mock_client_id)
-            assert.stub(lsp.buf_attach_client).was_called_with(mock_bufnr, mock_client_id)
-            assert.truthy(did_attach)
+            client.try_add(mock_bufnr, function(did_attach)
+                assert.stub(should_attach).was_called_with(mock_bufnr)
+                assert.stub(api.nvim_buf_get_option).was_called_with(mock_bufnr, "buftype")
+                assert.stub(api.nvim_buf_get_option).was_called_with(mock_bufnr, "filetype")
+                assert.stub(api.nvim_buf_get_name).was_called_with(mock_bufnr)
+                assert.stub(sources.get_all).was_called()
+                assert.stub(sources.is_available).was_called_with(mock_sources[1], "")
+                assert.stub(lsp.buf_is_attached).was_called_with(mock_bufnr, mock_client_id)
+                assert.stub(lsp.buf_attach_client).was_called_with(mock_bufnr, mock_client_id)
+                assert.truthy(did_attach)
+            end)
         end)
 
         it("should use cwd as root_dir", function()
@@ -200,10 +200,10 @@ describe("client", function()
             root_dir.returns(nil)
             c._set({ root_dir = root_dir })
 
-            client.try_add(mock_bufnr)
-
-            local opts = lsp.start_client.calls[1].refs[1]
-            assert.equals(opts.root_dir, vim.loop.cwd())
+            client.try_add(mock_bufnr, function()
+                local opts = lsp.start_client.calls[1].refs[1]
+                assert.equals(opts.root_dir, vim.loop.cwd())
+            end)
         end)
 
         it("should use custom root_dir", function()
@@ -211,53 +211,53 @@ describe("client", function()
             root_dir.returns("mock-root")
             c._set({ root_dir = root_dir })
 
-            client.try_add(mock_bufnr)
-
-            local opts = lsp.start_client.calls[1].refs[1]
-            assert.equals(opts.root_dir, "mock-root")
+            client.try_add(mock_bufnr, function()
+                local opts = lsp.start_client.calls[1].refs[1]
+                assert.equals(opts.root_dir, "mock-root")
+            end)
         end)
 
         it("should not attach if user-defined should_attach returns false", function()
             local should_attach = stub.new(nil, nil, false)
             c._set({ should_attach = should_attach })
 
-            local did_attach = client.try_add(mock_bufnr)
-
-            assert.stub(should_attach).was_called_with(mock_bufnr)
-            assert.falsy(did_attach)
+            client.try_add(mock_bufnr, function(did_attach)
+                assert.stub(should_attach).was_called_with(mock_bufnr)
+                assert.falsy(did_attach)
+            end)
         end)
 
         it("should not attach if buftype is not empty", function()
             api.nvim_buf_get_option.returns("nofile")
 
-            local did_attach = client.try_add(mock_bufnr)
-
-            assert.falsy(did_attach)
+            client.try_add(mock_bufnr, function()
+                assert.falsy(did_attach)
+            end)
         end)
 
         it("should not attach if name is empty", function()
             api.nvim_buf_get_name.returns("")
 
-            local did_attach = client.try_add(mock_bufnr)
-
-            assert.falsy(did_attach)
+            client.try_add(mock_bufnr, function()
+                assert.falsy(did_attach)
+            end)
         end)
 
         it("should not attach if no source is available", function()
             sources.is_available.returns(false)
 
-            local did_attach = client.try_add(mock_bufnr)
-
-            assert.falsy(did_attach)
+            client.try_add(mock_bufnr, function()
+                assert.falsy(did_attach)
+            end)
         end)
 
         it("should return true but not attach again if already attached", function()
             lsp.buf_is_attached.returns(true)
 
-            local did_attach = client.try_add(mock_bufnr)
-
-            assert.truthy(did_attach)
-            assert.stub(lsp.buf_attach_client).was_not_called()
+            client.try_add(mock_bufnr, function(did_attach)
+                assert.truthy(did_attach)
+                assert.stub(lsp.buf_attach_client).was_not_called()
+            end)
         end)
     end)
 

--- a/test/spec/utils/utils_spec.lua
+++ b/test/spec/utils/utils_spec.lua
@@ -420,4 +420,9 @@ describe("utils", function()
             assert.equals(test_path, u.root_pattern("minimal_init.lua")(start_path))
         end)
     end)
+
+    describe("root_pattern_async", function()
+        -- TODO: Here would be unit tests for root_pattern_async, but Plenary doesn't support them
+        -- (https://github.com/nvim-lua/plenary.nvim/issues/542)
+    end)
 end)


### PR DESCRIPTION
In this PR I implement a `root_dir_async` config field and a `root_pattern_async` utility that asynchronously find a desired root directory. This addresses #11 and prevents none-ls from blocking Neovim on potentially slow FS traversals.

I haven't made it the default config, because I don't feel confident doing so yet as this could be breaking for users.  