### PR TITLE
Fix `protolint` formating/diagnositics issues

### DIFF
--- a/doc/null-ls.txt
+++ b/doc/null-ls.txt
@@ -1,4 +1,4 @@
-*null-ls.txt*                                    Last change: 2023 November 24
+*null-ls.txt*                                    Last change: 2023 November 26
 
 ==============================================================================
 Table of Contents                                  *null-ls-table-of-contents*

--- a/lua/null-ls/builtins/diagnostics/protolint.lua
+++ b/lua/null-ls/builtins/diagnostics/protolint.lua
@@ -62,7 +62,11 @@ return h.make_builtin({
                 return done(issues)
             end
 
-            for _, issue in ipairs(decoded.lints or {}) do
+            local lints = {}
+            if decoded and decoded.lints and decoded.lints ~= vim.NIL then
+                lints = decoded.lints
+            end
+            for _, issue in ipairs(lints) do
                 -- We're forced to use to_temp_file since Protolint doesn't accept stdin input.
                 -- Due to the naming of temp files Protolint triggers 'FILE_NAMES_LOWER_SNAKE_CASE' error.
                 -- As a dirty quickfix we simple skip this.

--- a/lua/null-ls/builtins/diagnostics/protolint.lua
+++ b/lua/null-ls/builtins/diagnostics/protolint.lua
@@ -82,6 +82,7 @@ return h.make_builtin({
 
             done(issues)
         end,
+        prepend_extra_args = true,
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/formatting/protolint.lua
+++ b/lua/null-ls/builtins/formatting/protolint.lua
@@ -16,6 +16,7 @@ return h.make_builtin({
         args = { "--fix", "$FILENAME" },
         to_stdin = false,
         to_temp_file = true,
+        prepend_extra_args = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
As the `protolint` commit changes(https://github.com/yoheimuta/protolint/issues/340, https://github.com/yoheimuta/protolint/commit/1f2cba7a25adba6afcd8ea5e4fabb69cd4b8ef4f), I have to remove the rule `FILE_NAMES_LOWER_SNAKE_CASE` to make the `protolint` fix works.

I also tried add `extra_args`, but the `protolint` require the parameters before the target files.

After add this rule, the `diagnositics` broken, so we need more checks to pass the `decoded.lints` when its value is `vim.NIL`.