### PR TITLE
fix: diagnostic range in multi-byte lines

### DIFF
--- a/lua/null-ls/helpers/diagnostics.lua
+++ b/lua/null-ls/helpers/diagnostics.lua
@@ -63,6 +63,15 @@ local make_diagnostic = function(entries, defaults, attr_adapters, params, offse
     end
 
     local content_line = params.content and params.content[tonumber(entries["row"])] or nil
+
+    -- In order to match the correct range in lines with multi-byte characters,
+    -- we need to convert the column number to a byte index.
+    -- See: https://github.com/nvimtools/none-ls.nvim/issues/19#issuecomment-1820127436
+    if entries["col"] ~= nil and content_line ~= nil then
+        local byte_index_col = vim.str_byteindex(content_line, tonumber(entries["col"]))
+        entries["col"] = tostring(byte_index_col)
+    end
+
     for attr, adapter in pairs(attr_adapters) do
         entries[attr] = adapter(entries, content_line)
     end

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -320,6 +320,9 @@ describe("diagnostics", function()
         local file = {
             [[Any rule whose heading is ~~struck through~~ is deprecated, but still provided for backward-compatibility.]],
         }
+        local file_with_special_characters = {
+            [[• Any rule whose heading is ~~struck through~~ is deprecated, but still provided for backward-compatibility.]],
+        }
 
         it("should create a diagnostic", function()
             local output = [[rules.md:1:46:"is deprecated" may be passive voice]]
@@ -328,6 +331,17 @@ describe("diagnostics", function()
                 row = "1",
                 col = 47,
                 end_col = 59,
+                message = '"is deprecated" may be passive voice',
+            }, diagnostic)
+        end)
+
+        it("should set the correct diagnostic range on lines with multi-byte characters", function()
+            local output = [[rules.md:1:48:"is deprecated" may be passive voice]]
+            local diagnostic = parser(output, { content = file_with_special_characters })
+            assert.same({
+                row = "1",
+                col = 51,
+                end_col = 63,
                 message = '"is deprecated" may be passive voice',
             }, diagnostic)
         end)


### PR DESCRIPTION
When we parse the report produced by a source, we usually read and forward the column index, but in Lua, the index of a substring depends on the number of bytes in the string, not the number of printable characters.

For example, the line:

```
• Any rule whose heading is ~~struck through~~ is deprecated.
```

Produces the report:

```
text:1:47:"is deprecated" may be passive voice
```

But if we use that `47` to create the diagnostic, Lua will count 47 bytes, which will give us:

```lua
"~~ is deprecated"
```

Instead of

```lua
"is deprecated"
```

That's why we end up with the odd range described in #19.

Luckily, the Neovim team has a function to find the index we need through the function `vim.str_byteindex`.