### PR TITLE
Adds formatter for D2

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2924,6 +2924,23 @@ local sources = { null_ls.builtins.formatting.cue_fmt }
 - Command: `cue`
 - Args: `{ "fmt", "$FILENAME" }`
 
+### [d2_fmt](https://github.com/terrastruct/d2)
+
+Use [d2](https://github.com/terrastruct/d2) to format d2 diagram source.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.d2_fmt }
+```
+
+#### Defaults
+
+- Filetypes: `{ "d2" }`
+- Method: `formatting`
+- Command: `d2`
+- Args: `{ "fmt", "-" }`
+
 ### [dart_format](https://dart.dev/tools/dart-format)
 
 Replace the whitespace in your program with formatting that follows Dart guidelines.

--- a/lua/null-ls/builtins/formatting/d2_fmt.lua
+++ b/lua/null-ls/builtins/formatting/d2_fmt.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "d2 fmt",
+    meta = {
+        url = "https://github.com/terrastruct/d2",
+        description = "d2 fmt is a tool built into the d2 compiler for formatting d2 diagram source",
+    },
+    method = FORMATTING,
+    filetypes = { "d2" },
+    generator_opts = {
+        command = "d2",
+        args = { "fmt", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
This PR adds a formatter builtin for the [d2](https://github.com/terrastruct/d2) diagramming language.

I have manually tested and confirmed it works as expected.