### PR TITLE
fix: plenary log path

### DIFF
--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -51,7 +51,7 @@ end
 ---Retrieves the path of the logfile
 ---@return string path of the logfile
 function log:get_path()
-    return u.path.join(vim.fn.stdpath("cache"), "null-ls")
+    return u.path.join(vim.fn.stdpath("cache"), "null-ls.log")
 end
 
 ---Add a log entry at TRACE level

--- a/test/spec/logger_spec.lua
+++ b/test/spec/logger_spec.lua
@@ -2,7 +2,7 @@ local logger = require("null-ls.logger")
 
 describe("logger", function()
     it("get_path should return log file path from cache folder", function()
-        local expected = vim.fn.stdpath("cache") .. "/" .. "null-ls"
+        local expected = vim.fn.stdpath("cache") .. "/" .. "null-ls.log"
         assert.equals(expected, logger.get_path())
     end)
 end)


### PR DESCRIPTION
they added .log suffix again

https://github.com/nvim-lua/plenary.nvim/pull/546