### PR TITLE
revert: Revert wrongly removed ruff_format

### DIFF
--- a/lua/null-ls/builtins/formatting/ruff_format.lua
+++ b/lua/null-ls/builtins/formatting/ruff_format.lua
@@ -1,0 +1,20 @@
+local methods = require("null-ls.methods")
+local h = require("null-ls.helpers")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "ruff",
+    meta = {
+        url = "https://github.com/charliermarsh/ruff/",
+        description = "An extremely fast Python linter and formatter, written in Rust.",
+    },
+    method = FORMATTING,
+    filetypes = { "python" },
+    generator_opts = {
+        command = "ruff",
+        args = { "format", "-n", "--stdin-filename", "$FILENAME", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
https://github.com/nvimtools/none-ls.nvim/pull/41 removed `ruff_format` by mistake, this is restoring it back.

Check https://github.com/nvimtools/none-ls.nvim/pull/41#issuecomment-1843406374 and https://github.com/nvimtools/none-ls.nvim/pull/41#issuecomment-1843410187 for an explanation to why they are not the same thing.
