### PR TITLE
feat: support Python with Ruff in dprint

### DIFF
--- a/lua/null-ls/builtins/formatting/dprint.lua
+++ b/lua/null-ls/builtins/formatting/dprint.lua
@@ -22,6 +22,7 @@ return h.make_builtin({
         "json",
         "jsonc",
         "markdown",
+        "python",
         "toml",
         "rust",
         "roslyn",


### PR DESCRIPTION
dprint supports formatting Python with Ruff: https://dprint.dev/plugins/ruff/