### PR TITLE
chore: update ruff meta info

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ruff.lua
+++ b/lua/null-ls/builtins/diagnostics/ruff.lua
@@ -47,7 +47,7 @@ local custom_end_col = {
 return h.make_builtin({
     name = "ruff",
     meta = {
-        url = "https://github.com/charliermarsh/ruff/",
+        url = "https://github.com/astral-sh/ruff/",
         description = "An extremely fast Python linter, written in Rust.",
     },
     method = DIAGNOSTICS,

--- a/lua/null-ls/builtins/formatting/ruff.lua
+++ b/lua/null-ls/builtins/formatting/ruff.lua
@@ -6,7 +6,7 @@ local FORMATTING = methods.internal.FORMATTING
 return h.make_builtin({
     name = "ruff",
     meta = {
-        url = "https://github.com/charliermarsh/ruff/",
+        url = "https://github.com/astral-sh/ruff/",
         description = "An extremely fast Python linter, written in Rust.",
     },
     method = FORMATTING,

--- a/lua/null-ls/builtins/formatting/ruff_format.lua
+++ b/lua/null-ls/builtins/formatting/ruff_format.lua
@@ -6,8 +6,8 @@ local FORMATTING = methods.internal.FORMATTING
 return h.make_builtin({
     name = "ruff",
     meta = {
-        url = "https://github.com/charliermarsh/ruff/",
-        description = "An extremely fast Python linter and formatter, written in Rust.",
+        url = "https://github.com/astral-sh/ruff/",
+        description = "An extremely fast Python formatter, written in Rust.",
     },
     method = FORMATTING,
     filetypes = { "python" },


### PR DESCRIPTION
- Updated Ruff URL.
- `ruff_format` is only for formatting, not a linter.