### PR TITLE
fix(formatting): npm_groovy_lint.lua: fix timeout and no error

### DIFF
--- a/lua/null-ls/builtins/formatting/npm_groovy_lint.lua
+++ b/lua/null-ls/builtins/formatting/npm_groovy_lint.lua
@@ -13,7 +13,8 @@ return h.make_builtin({
     filetypes = { "groovy", "java", "Jenkinsfile" },
     generator_opts = {
         command = "npm-groovy-lint",
-        args = { "--format", "-" },
+        args = { "--failon", "none", "--format", "-" },
+        timeout = 5000,
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Fix npm-groovy-lint, `--failon none` causes the script to always exit 0 (desired in this case of formatting), and increase the timeout for the cli that can take time