### PR TITLE
fix(code actions): don't sort actions by title

### DIFF
--- a/lua/null-ls/code-actions.lua
+++ b/lua/null-ls/code-actions.lua
@@ -34,11 +34,6 @@ M.handler = function(method, original_params, handler)
             callback = function(actions)
                 log:trace("received code actions from generators")
                 log:trace(vim.inspect(actions))
-
-                -- sort actions by title
-                table.sort(actions, function(a, b)
-                    return a.title < b.title
-                end)
                 handler(actions)
             end,
         })


### PR DESCRIPTION
Not all code action sources want their actions to be sorted alphabetically.

The source itself should determine the order of the actions by how they add them to the return table.

See: https://github.com/nvimtools/none-ls.nvim/discussions/62