### PR TITLE
feat(builtins): add vfmt as a formatting builtin

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -5114,6 +5114,23 @@ local sources = { null_ls.builtins.formatting.usort }
 - Command: `usort`
 - Args: `{ "format", "-" }`
 
+### [vfmt](https://github.com/vlang/v)
+
+Reformat Vlang source into canonical form.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.vfmt }
+```
+
+#### Defaults
+
+- Filetypes: `{ "vlang" }`
+- Method: `formatting`
+- Command: `v`
+- Args: `{ "fmt", "-w", "$FILENAME" }`
+
 ### [verible_verilog_format](https://github.com/chipsalliance/verible)
 
 The verible-verilog-format formatter manages whitespace in accordance with a particular style. The main goal is to relieve humans of having to manually manage whitespace, wrapping, and indentation, and to provide a tool that can be integrated into any editor to enable editor-independent consistency.

--- a/lua/null-ls/builtins/formatting/vfmt.lua
+++ b/lua/null-ls/builtins/formatting/vfmt.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "vfmt",
+    meta = {
+        url = "https://github.com/vlang/v",
+        description = "Reformat Vlang source into canonical form.",
+    },
+    method = FORMATTING,
+    filetypes = { "vlang" },
+    generator_opts = {
+        command = "v",
+        args = { "fmt", "-w", "$FILENAME" },
+        to_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Hello

This pull request adds [vfmt](https://github.com/vlang/v/blob/master/doc/docs.md#v-fmt) as a builtin formatter for [Vlang](https://vlang.io) code.