### PR TITLE
feat(rubocop): Enable --server by default

### DIFF
--- a/lua/null-ls/builtins/formatting/rubocop.lua
+++ b/lua/null-ls/builtins/formatting/rubocop.lua
@@ -17,6 +17,7 @@ return h.make_builtin({
             -- NOTE: For backwards compatibility,
             -- we are still using "-a" shorthand' for both "--auto-correct" (pre-1.3.0) and "--autocorrect" (1.3.0+).
             "-a",
+            "--server",
             "-f",
             "quiet",
             "--stderr",


### PR DESCRIPTION
Enable `--server` by default since is way [faster](https://docs.rubocop.org/rubocop/usage/server.html) and rubocop has this feature for quite a while, without it its pretty laggy.