### PR TITLE
fix(ansiblelint): Support to the latest output format

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -29,11 +29,20 @@ return h.make_builtin({
             params.messages = {}
             for _, message in ipairs(params.output) do
                 if params.temp_path:match(vim.pesc(message.location.path)) then
+                    local row = nil
                     local col = nil
-                    local row = message.location.lines.begin
-                    if type(row) == "table" then
-                        row = row.line
-                        col = row.column
+
+                    -- Check if the location has the old or new format
+                    if type(message.location.lines) == "table" then
+                        row = message.location.lines.begin
+                        if type(row) == "table" then
+                            row = row.line
+                            col = row.column
+                        end
+                    elseif type(message.location.positions) == "table" then
+                        local positions = message.location.positions
+                        row = positions.begin.line
+                        col = positions.begin.column
                     end
                     table.insert(params.messages, {
                         row = row,


### PR DESCRIPTION
I installed ansiblelint and tried to make it work with none-ls but it seems the latest version (v6.22.x) I installed changed the output to the outdated (v5.x)

This code change makes sure it can handle the v6 format and keeps backwards compatibility with the legacy v5 via some simple object detection.

This is the new format you get from ansiblelint v6


```json
[
  {
    "type": "issue",
    "check_name": "syntax-check[specific]",
    "categories": [
      "core"
    ],
    "url": "https://ansible-lint.readthedocs.io/rules/syntax-check/",
    "severity": "blocker",
    "level": "error",
    "description": "'tasks' is not a valid attribute for a PlaybookInclude",
    "fingerprint": "62bced6ef793c4d2c8e8922429b1baf4d75f19a67d2c8cbe4c40967e90157b47",
    "location": {
      "path": "playbook/update-install-pusher.yml",
      "positions": {
        "begin": {
          "line": 7,
          "column": 3
        }
      }
    }
  }
]
```

The old format (v5)

```json
[
  {
    "type": "issue",
    "check_name": "[syntax-check] 'tasks' is not a valid attribute for a PlaybookInclude",
    "categories": [
      "core",
      "unskippable"
    ],
    "severity": "blocker",
    "description": "...[truncated]...",
    "fingerprint": "575853e16b67ca74e2340f72a4ea1d83ed8c1b47ea351faa4409cb9676ba5716",
    "location": {
      "path": "playbook/update-install-pusher.yml",
      "lines": {
        "begin": {
          "line": 7,
          "column": 3
        }
      }
    },
    "content": {
      "body": "...[truncated]..."
    }
  }
]
```