### PR TITLE
feat(builtins): add Gleam format

### DIFF
--- a/lua/null-ls/builtins/formatting/gleam_format.lua
+++ b/lua/null-ls/builtins/formatting/gleam_format.lua
@@ -1,0 +1,24 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "gleam_format",
+    meta = {
+        url = "https://github.com/gleam-lang/gleam/",
+        description = [[Default formater for the Gleam programming language]],
+    },
+    method = { FORMATTING },
+    filetypes = { "gleam" },
+    generator_opts = {
+        command = "gleam",
+        args = { "format", "--stdin" },
+        to_stdin = true,
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern("gleam.toml")(params.bufname)
+        end),
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
[Gleam](https://gleam.run/) just got its 1.0 release and, after trying it out myself, I noticed it didn't have a builtin formatter in none-ls. So here I am adding it.