### PR TITLE
feat(builtins): add Fortran findent code formatter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2400,6 +2400,23 @@ local sources = { null_ls.builtins.formatting.fantomas }
 - Command: `fantomas`
 - Args: `{ "$FILENAME" }`
 
+### [findent](https://github.com/gnikit/findent-pypi)
+
+findent indents/beautifies/converts and can optionally generate the dependencies of Fortran sources.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.findent }
+```
+
+#### Defaults
+
+- Filetypes: `{ "fortran" }`
+- Method: `formatting`
+- Command: `findent`
+- Args: `{}`
+
 ### [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html)
 
 Indent or otherwise prettify a piece of fish code.

--- a/doc/builtins.json
+++ b/doc/builtins.json
@@ -690,6 +690,11 @@
         "fsharp"
       ]
     },
+    "findent": {
+      "filetypes": [
+        "fortran"
+      ]
+    },
     "fish_indent": {
       "filetypes": [
         "fish"

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -118,7 +118,7 @@ return {
     formatting = { "fnlfmt" }
   },
   fortran = {
-    formatting = { "fprettify" }
+    formatting = { "findent", "fprettify" }
   },
   fsharp = {
     formatting = { "fantomas" }

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -100,6 +100,9 @@ return {
   fantomas = {
     filetypes = { "fsharp" }
   },
+  findent = {
+    filetypes = { "fortran" }
+  },
   fish_indent = {
     filetypes = { "fish" }
   },

--- a/lua/null-ls/builtins/formatting/findent.lua
+++ b/lua/null-ls/builtins/formatting/findent.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "findent",
+    meta = {
+        url = "https://pypi.org/project/findent/",
+        description = "findent indents/beautifies/converts and can optionally generate the dependencies of Fortran sources.",
+    },
+    method = FORMATTING,
+    filetypes = { "fortran" },
+    generator_opts = {
+        command = "findent",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
This PR adds the builtin support for findent, the Fortran code formatter. I have tested it locally using none-ls from my fork, and it passes the tests as well (`make test`).