### PR TITLE
docs(refactoring): accomodate changes in neovim api

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -132,7 +132,7 @@ local sources = { null_ls.builtins.code_actions.refactoring }
 
 #### Notes
 
-- Requires visually selecting the code you want to refactor and calling `:'<,'>lua vim.lsp.buf.range_code_action()` (for the default handler) or `:'<,'>Telescope lsp_range_code_actions` (for Telescope).
+- Requires visually selecting the code you want to refactor and calling `:'<,'>lua vim.lsp.buf.code_action()`.
 
 ### [statix](https://github.com/nerdypepper/statix)
 

--- a/lua/null-ls/builtins/code_actions/refactoring.lua
+++ b/lua/null-ls/builtins/code_actions/refactoring.lua
@@ -9,7 +9,7 @@ return h.make_builtin({
         url = "https://github.com/ThePrimeagen/refactoring.nvim",
         description = "The Refactoring library based off the Refactoring book by Martin Fowler.",
         notes = {
-            [[Requires visually selecting the code you want to refactor and calling `:'<,'>lua vim.lsp.buf.range_code_action()` (for the default handler) or `:'<,'>Telescope lsp_range_code_actions` (for Telescope).]],
+            [[Requires visually selecting the code you want to refactor and calling `:'<,'>lua vim.lsp.buf.code_action()`]],
         },
     },
     method = CODE_ACTION,


### PR DESCRIPTION
In the refactoring builtin, changed the instruction to use ```vim.lsp.buf.range_code_action()``` to use ```vim.lsp.buf.code_action()``` as the former was deprecated in favor of the latter. See [here](https://neovim.io/doc/user/deprecated.html#vim.lsp.buf.range_code_action)
Also removed the instruction to use telescope code action (deprecated as well. See [here](https://github.com/nvim-telescope/telescope.nvim/pull/1866/files))