### PR TITLE
feat(builtins): add bean-check linter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -289,6 +289,22 @@ local sources = { null_ls.builtins.diagnostics.ansiblelint }
 - Command: `ansible-lint`
 - Args: `{ "-f", "codeclimate", "-q", "--nocolor", "$FILENAME" }`
 
+### [bean_check](https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-check)
+
+This tool will check beancount files for spending errors, balance mismatches and more.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.bean_check }
+```
+
+#### Defaults
+
+- Filetypes: `{ "beancount" }`
+- Method: `diagnostics`
+- Command: `bean-check`
+
 ### [bslint](https://github.com/rokucommunity/bslint)
 
 A brighterscript CLI tool to lint your code without compiling your project.

--- a/lua/null-ls/builtins/diagnostics/bean_check.lua
+++ b/lua/null-ls/builtins/diagnostics/bean_check.lua
@@ -1,0 +1,26 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
+
+return h.make_builtin({
+    name = "bean_check",
+    meta = {
+        url = "https://github.com/beancount/beancount",
+        description = "Beancount: text-based double-entry accounting tool",
+    },
+    method = DIAGNOSTICS_ON_SAVE,
+    filetypes = { "beancount" },
+    generator = h.generator_factory{
+        command = "bean-check",
+        args = { "$FILENAME" },
+        from_stderr = true,
+        to_stdin = true,
+        format = "line",
+        check_exit_code = function(exit_code) return exit_code == 0 end,
+        on_output = h.diagnostics.from_patterns{{
+            pattern = [[(.+):(%d+):%s*(.+)]],
+            groups = { "filename", "row", "message" },
+        }},
+    },
+})

--- a/lua/null-ls/builtins/diagnostics/bean_check.lua
+++ b/lua/null-ls/builtins/diagnostics/bean_check.lua
@@ -11,16 +11,20 @@ return h.make_builtin({
     },
     method = DIAGNOSTICS_ON_SAVE,
     filetypes = { "beancount" },
-    generator = h.generator_factory{
+    generator = h.generator_factory({
         command = "bean-check",
         args = { "$FILENAME" },
         from_stderr = true,
         to_stdin = true,
         format = "line",
-        check_exit_code = function(exit_code) return exit_code == 0 end,
-        on_output = h.diagnostics.from_patterns{{
-            pattern = [[(.+):(%d+):%s*(.+)]],
-            groups = { "filename", "row", "message" },
-        }},
-    },
+        check_exit_code = function(exit_code)
+            return exit_code == 0
+        end,
+        on_output = h.diagnostics.from_patterns({
+            {
+                pattern = [[(.+):(%d+):%s*(.+)]],
+                groups = { "filename", "row", "message" },
+            },
+        }),
+    }),
 })


### PR DESCRIPTION
We already have `bean-format` as a builtin. This pull request adds the complementary diagnostics counterpart, `bean-check`.