### PR TITLE
feat(prettier, prettierd): added `svelte` and `astro` filetypes

### DIFF
--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -12,7 +12,7 @@ return h.make_builtin({
         url = "https://github.com/prettier/prettier",
         description = [[Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.]],
         notes = {
-            [[Supports more filetypes such as [Svelte](https://github.com/sveltejs/prettier-plugin-svelte) and [TOML](https://github.com/bd82/toml-tools/tree/master/packages/prettier-plugin-toml) via plugins. These filetypes are not enabled by default, but you can follow the instructions [here](BUILTIN_CONFIG.md#filetypes) to define your own list of filetypes.]],
+            [[[TOML](https://github.com/bd82/toml-tools/tree/master/packages/prettier-plugin-toml) via plugins. These filetypes are not enabled by default, but you can follow the instructions [here](BUILTIN_CONFIG.md#filetypes) to define your own list of filetypes.]],
             [[To increase speed, you may want to try [prettierd](https://github.com/fsouza/prettierd). You can also set up [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) and format via [eslint_d](https://github.com/mantoni/eslint_d.js/).]],
         },
     },
@@ -34,6 +34,8 @@ return h.make_builtin({
         "markdown.mdx",
         "graphql",
         "handlebars",
+        "svelte",
+        "astro",
     },
     generator_opts = {
         command = "prettier",

--- a/lua/null-ls/builtins/formatting/prettierd.lua
+++ b/lua/null-ls/builtins/formatting/prettierd.lua
@@ -30,6 +30,8 @@ return h.make_builtin({
         "markdown.mdx",
         "graphql",
         "handlebars",
+        "svelte",
+        "astro",
     },
     generator_opts = {
         command = "prettierd",


### PR DESCRIPTION
I was using the filetypes `svelte` and `astro` with `formatting.prettierd.with({ extra_filetypes = { "astro", "svelte" }})` and it works fine.

I think we should add those in the `filetypes` entry.

> [!note]
> [Eslint lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#eslint) now is updated to work with these filetypes