### PR TITLE
fix(biome): use stdin

### DIFF
--- a/lua/null-ls/builtins/formatting/biome.lua
+++ b/lua/null-ls/builtins/formatting/biome.lua
@@ -20,15 +20,14 @@ return h.make_builtin({
         command = "biome",
         args = {
             "format",
-            "--write",
+            "--stdin-file-path",
             "$FILENAME",
         },
         dynamic_command = cmd_resolver.from_node_modules(),
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern("rome.json", "biome.json", "biome.jsonc")(params.bufname)
         end),
-        to_stdin = false,
-        to_temp_file = true,
+        to_stdin = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
Using temp_file may change the file name and cause it to be formatted even though it is specified as ignore in the biome configuration.
`biome format` supports stdin.
see https://biomejs.dev/reference/cli/#biome-format
> --stdin-file-path=PATH — Use this option when you want to format code piped from stdin, and print the output to stdout.