### PR TITLE
feat(biome): add biome_check

### DIFF
--- a/lua/null-ls/builtins/formatting/biome_check.lua
+++ b/lua/null-ls/builtins/formatting/biome_check.lua
@@ -1,0 +1,34 @@
+local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
+local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "biome_check",
+    meta = {
+        url = "https://biomejs.dev",
+        description = "Formatter, linter, bundler, and more for JavaScript, TypeScript, JSON, HTML, Markdown, and CSS.",
+        notes = {
+            "Currently support only JavaScript, TypeScript and JSON. See status [here](https://biomejs.dev/internals/language-support/)",
+        },
+    },
+    method = FORMATTING,
+    filetypes = { "javascript", "typescript", "javascriptreact", "typescriptreact", "json", "jsonc" },
+    generator_opts = {
+        command = "biome",
+        args = {
+            "check",
+            "--apply",
+            "--stdin-file-path",
+            "$FILENAME",
+        },
+        dynamic_command = cmd_resolver.from_node_modules(),
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern("rome.json", "biome.json", "biome.jsonc")(params.bufname)
+        end),
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
`biome format` supports only formatting, but `biome check` supports formatting, auto fixes and import sorting.

see https://biomejs.dev/reference/cli/#biome-check