### PR TITLE
✨feat(`reformat-gherkin`): added `gherkin` formatter (`cucumber`).

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3350,6 +3350,23 @@ local sources = { null_ls.builtins.formatting.raco_fmt }
 - Requires Racket 8.0 or later
 - Install with `raco pkg install fmt`
 
+### [reformat-gherkin](https://github.com/ducminh-phan/reformat-gherkin)
+
+Formatter for Gherkin language.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.reformat_gherkin }
+```
+
+#### Defaults
+
+- Filetypes: `{ "cucumber" }`
+- Method: `formatting`
+- Command: `reformat-gherkin`
+- Args: `{ "$FILENAME" }`
+
 ### [rego](https://www.openpolicyagent.org/docs/latest/policy-language)
 
 Rego (opa fmt) Formatter

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3362,7 +3362,7 @@ local sources = { null_ls.builtins.formatting.reformat_gherkin }
 
 #### Defaults
 
-- Filetypes: `{ "cucumber" }`
+- Filetypes: `{ "cucumber", "gherkin" }`
 - Method: `formatting`
 - Command: `reformat-gherkin`
 - Args: `{ "$FILENAME" }`

--- a/doc/builtins.json
+++ b/doc/builtins.json
@@ -999,6 +999,11 @@
         "racket"
       ]
     },
+    "reformat_gherkin": {
+      "filetypes": [
+        "cucumber"
+      ]
+    },
     "rego": {
       "filetypes": [
         "rego"

--- a/doc/builtins.json
+++ b/doc/builtins.json
@@ -1001,7 +1001,8 @@
     },
     "reformat_gherkin": {
       "filetypes": [
-        "cucumber"
+        "cucumber",
+        "gherkin"
       ]
     },
     "rego": {

--- a/lua/null-ls/builtins/formatting/reformat_gherkin.lua
+++ b/lua/null-ls/builtins/formatting/reformat_gherkin.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "reformat-gherkin",
+    meta = {
+        url = "https://github.com/ducminh-phan/reformat-gherkin",
+        description = "Formatter for Gherkin language.",
+    },
+    method = FORMATTING,
+    filetypes = { "cucumber" },
+    generator_opts = {
+        command = "reformat-gherkin",
+        args = { "$FILENAME" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})

--- a/lua/null-ls/builtins/formatting/reformat_gherkin.lua
+++ b/lua/null-ls/builtins/formatting/reformat_gherkin.lua
@@ -10,7 +10,7 @@ return h.make_builtin({
         description = "Formatter for Gherkin language.",
     },
     method = FORMATTING,
-    filetypes = { "cucumber" },
+    filetypes = { "cucumber", "gherkin" },
     generator_opts = {
         command = "reformat-gherkin",
         args = { "$FILENAME" },


### PR DESCRIPTION
aka `.feature` files.

## How to test
* Clone this branch.
* Use `mason` to install `reformat-gherkin` (filter by `cucumber` to find it).
* Open a `.feature` file (examples [here](https://github.com/ducminh-phan/reformat-gherkin/tree/master/tests/gherkin_test_data))
* If you are using `mason-null-ls.nvim`, you should see the formatter correctly loaded (botton-right on the image). If not, you can load it manually.
![screenshot_2024-05-10_16-56-37_347294487](https://github.com/nvimtools/none-ls.nvim/assets/3357792/17b63714-cdaf-4e40-97b7-0cf89f389da8)

Now you can format the code!

## More info
* Cucumber is a QA tool.
* Gherkin is the name of the language used by cucumber.
* Gherkin files have the `.feature` extension.
* Neovim assign the filetype `cucumber` to `.feature` files.
* As this is likely to be a mistake, we also support the `gherkin` filetype.