### PR TITLE
🐛fix(client): we dont want to attach a source if its command is not executable.

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -22,7 +22,15 @@ local should_attach = function(bufnr)
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
     for _, source in ipairs(sources.get_all()) do
         if sources.is_available(source, ft) then
-            return true
+
+            -- if a command is defined, attach only if it's executable
+            local opts = source.generator.opts
+            if opts and opts.command then
+                if vim.fn.executable(opts.command) == 1 then
+                    return true
+                end
+            end
+
         end
     end
 

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -22,15 +22,7 @@ local should_attach = function(bufnr)
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
     for _, source in ipairs(sources.get_all()) do
         if sources.is_available(source, ft) then
-
-            -- if a command is defined, attach only if it's executable
-            local opts = source.generator.opts
-            if opts and opts.command then
-                if vim.fn.executable(opts.command) == 1 then
-                    return true
-                end
-            end
-
+            return true
         end
     end
 

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -98,8 +98,21 @@ local register_source = function(source)
     registered.names[source.name] = true
 end
 
+M.is_executable = function(source)
+    -- for sources with a command
+    if source.generator.opts.command then
+        if vim.fn.executable(source.generator.opts.command) == 0 then
+          -- if the command is not executable
+          return false
+        end
+    end
+
+    -- for the rest
+    return true
+end
+
 M.is_available = function(source, filetype, method)
-    if source._disabled or source.generator._failed then
+    if not is_executable(source) or source._disabled or source.generator._failed then
         return false
     end
 

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -103,6 +103,7 @@ M.is_executable = function(source)
     if source.generator.opts.command then
         if vim.fn.executable(source.generator.opts.command) == 0 then
             -- if the command is not executable
+            log:error("failed to execute command: " .. source.generator.opts.command)
             return false
         end
     end

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -112,7 +112,7 @@ M.is_executable = function(source)
 end
 
 M.is_available = function(source, filetype, method)
-    if not is_executable(source) or source._disabled or source.generator._failed then
+    if not M.is_executable(source) or source._disabled or source.generator._failed then
         return false
     end
 


### PR DESCRIPTION
(for sources which command is different than nil).

## Problem
A explicitly registered external source will be attached even if the source command is not actually executable. This create several unwanted scenarios:

* When a user uninstall the mason package of a registered external source, none-ls currently attach it anyway.
* Trying to run the non existing command will display an error.

This is inconsistent with the behavior of builtins, which will only attach if the executable is available. This inconsistent behavior is likely to be a regression.

## Example
The next formatter appear attached even though we uninstalled it and rebooted neovim (bottom right of the image).
![screenshot_2024-05-10_18-49-50_149890376](https://github.com/nvimtools/none-ls.nvim/assets/3357792/32fb34df-9c5e-4ea2-9c77-fbb793297b1c)

Trying to run the formatter will of cause an error.
![screenshot_2024-05-10_18-51-58_029003400](https://github.com/nvimtools/none-ls.nvim/assets/3357792/e6841c11-daab-4585-85ed-b5283a4d51a0)

## Solution
* By not allowing clients to be attached if their executable do not exist, it's not possible to have an inconsistent state anymore.
* Builtins and external sources now behave the same.