### PR TITLE
fix(ktlint): bug where buffer is clobbered by ktlint formatter

### DIFF
--- a/lua/null-ls/builtins/formatting/ktlint.lua
+++ b/lua/null-ls/builtins/formatting/ktlint.lua
@@ -16,6 +16,7 @@ return h.make_builtin({
         args = {
             "--format",
             "--stdin",
+            "--log-level=none",
             "**/*.kt",
             "**/*.kts",
         },


### PR DESCRIPTION
The ktlint formatter clobbers your current Neovim buffer with log errors and warnings. This is especially problematic when working with Kotlin Script files. 

If you have something like this in your buffer:
```
#!/usr/bin/env kotlin

println("Hello World!")
```
and write the file, triggering the formatter, you'll end up with something like this:
```
04:27:56.342 [main] WARN com.pinterest.ktlint.cli.internal.KtlintCommandLine -- Can not parse input from <stdin> as Kotlin, due to error below:
    Not a valid Kotlin file (3:1 expecting a top level declaration)
Now, trying to read the input as Kotlin Script.
#!/usr/bin/env kotlin

println("Hello World!")
```

I just went through some old PR's, and it looks like a similar thing happened on the diagnostic side, and they came up with the same fix: https://github.com/nvimtools/none-ls.nvim/pull/75