### PR TITLE
feat: add opentofu-fmt formatter

### DIFF
--- a/lua/null-ls/builtins/formatting/opentofu_fmt.lua
+++ b/lua/null-ls/builtins/formatting/opentofu_fmt.lua
@@ -1,0 +1,23 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "opentofu_fmt",
+    meta = {
+        url = "https://opentofu.org/docs/cli/commands/fmt/#usage",
+        description = "The opentofu-fmt command rewrites `opentofu` configuration files to a canonical format and style.",
+    },
+    method = FORMATTING,
+    filetypes = { "terraform", "tf", "terraform-vars" },
+    generator_opts = {
+        command = "tofu",
+        args = {
+            "fmt",
+            "-",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Hi! I have been an avid user of null-ls before, and switched to none-ls.nvim. Thanks for keeping this project alive 👍 

This adds the `opentofu-fmt` formatter, in addition to terraform. It is mutually exclusive with the terraform one, as both are use to format the terraform filetypes.

Most of the code is duplicate from the terraform one, but I don't think there is a simpler/more straightforward way to include opentofu in the codebase. If there is, feel free to point me in the right direction. 

Opentofu is a fork which maintains the open source Apache 2.0 license of Terraform, after it switched to the non opensource BSL. See its [manifesto](https://opentofu.org/manifesto/).

Not sure if relevant, but I would be happy to maintain this formatter.