### PR TITLE
doc: rephrase source name explanation

### DIFF
--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -36,8 +36,8 @@ Sources must be **registered**, either by the user or by an integration, before
 they are active. You can get, set, and manipulate sources using the source API,
 as described in [SOURCES](./SOURCES.md).
 
-Sources can also define a **name**, which allows integrations to see if sources
-null-ls has already registered their sources to prevent duplicate registration.
+Sources can also define a **name**, which allows integrations to check whether
+null-ls has already registered them to prevent duplicate registration.
 
 Sources may define a **condition**, which determines whether null-ls should
 register the source.


### PR DESCRIPTION
Hey!

I'm in an ongoing pursuit of adding none-ls to my configuration. While browsing the docs, I stumbled across this difficult sentence.


> Sources can also define a **name**, which allows integrations to see if sources
> null-ls has already registered their sources to prevent duplicate registration.

While the sentence gets the point across after 2 or 3 reads, I feel that it could be made more clearer. Especially as it is among the first sentences readers consume when browsing through the docs, just as I did.

Thanks for the great work! Can't wait to continue to try none-ls!