### PR TITLE
builtins/diagnostics: update `sqlfluff lint` output format

### DIFF
--- a/lua/null-ls/builtins/diagnostics/sqlfluff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqlfluff.lua
@@ -37,8 +37,9 @@ local sources = {
         end,
         on_output = helpers.diagnostics.from_json({
             attributes = {
-                row = "line",
+                row = "start_line",
                 col = "start_column",
+                end_row = "end_line",
                 end_col = "end_column",
                 severity = "annotation_level",
                 message = "message",


### PR DESCRIPTION
Hi, I'm new here! When I tried to setup my neovim environment last week, I found an update of `sqlfluff lint` output when ver 3.0.0 released, leading to unaesthetics diagnostics injection.Hopefully, this PR could help.

- As mentioned in sqlfluff [changelog](https://github.com/sqlfluff/sqlfluff/blob/main/CHANGELOG.md), the serialized output of `sqlfluff lint` renamed from `line_pos` and `line_no` to `start_line_pos` and `start_line_no`.

- Below is the printed `ipairs(params.output)` from neovim `:message`   
![serialized output](https://github.com/nvimtools/none-ls.nvim/assets/76949256/2df455d2-86d2-4986-8091-2557bdf706cb)
