### PR TITLE
feat(builtins): add typstyle formatter for typst

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3869,6 +3869,23 @@ local sources = { null_ls.builtins.formatting.typstfmt }
 - Command: `typstfmt`
 - Args: `{ "-o", "-" }`
 
+### [typstyle](https://github.com/Enter-tainer/typstyle/)
+
+Formatter for typst
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.typstyle }
+```
+
+#### Defaults
+
+- Filetypes: `{ "typ", "typst" }`
+- Method: `formatting`
+- Command: `typstyle`
+- Args: `{}`
+
 ### [uncrustify](https://github.com/uncrustify/uncrustify)
 
 A source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and Vala.

--- a/lua/null-ls/builtins/formatting/typstyle.lua
+++ b/lua/null-ls/builtins/formatting/typstyle.lua
@@ -1,0 +1,19 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "typstyle",
+    meta = {
+        url = "https://github.com/Enter-tainer/typstyle/",
+        description = "Beautiful and reliable typst code formatter",
+    },
+    method = FORMATTING,
+    filetypes = { "typ", "typst" },
+    generator_opts = {
+        command = "typstyle",
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Hello, this adds the [typstyle](https://github.com/Enter-tainer/typstyle/) formatter for `typst` files.

One thing I'm not 100% sure on is if I needed to update the `doc/BUILTINS.md` file or not to reflect this change -- seems there's a CI runner that auto updates the docs. Wasn't sure if that covered generating that or not.

Let me know if you desire any changes, I'll be happy to make 'em.