### PR TITLE
fix(builtins): prevent erb_lint false header match

### DIFF
--- a/lua/null-ls/builtins/formatting/erb_lint.lua
+++ b/lua/null-ls/builtins/formatting/erb_lint.lua
@@ -20,7 +20,7 @@ return h.make_builtin({
         output = "raw",
         on_output = function(params, done)
             local output = params.output
-            local metadata_end = output:match(".*==()") + 1
+            local metadata_end = output:match(".*====()") + 1
             return done({ { text = output:sub(metadata_end) } })
         end,
     },


### PR DESCRIPTION
An output:match is performed to detect the header of the linter output to exclude it from being injected into the buffer. 
However, it matches on `==`, which is also a legitimate Ruby operator.
When `==` is encountered in the code, it causes the buffer up to and including that operator to be deleted.

Because the linter output uses 16 `=` symbols in its header, adding an additional `==` to the match will still work while not causing false matches with legitimate uses of `==`.