### PR TITLE
feat(builtins): add mdslw formatter for markdown

### DIFF
--- a/lua/null-ls/builtins/formatting/mdslw.lua
+++ b/lua/null-ls/builtins/formatting/mdslw.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "mdslw",
+    meta = {
+        url = "https://github.com/razziel89/mdslw",
+        description = [[The MarkDown Sentence Line Wrapper, an auto-formatter that prepares your markdown for easy diff'ing.]],
+    },
+    method = FORMATTING,
+    filetypes = { "markdown" },
+    generator_opts = {
+        command = "mdslw",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
If people want, I can add configuration to the plugin, I just can't figure out how to consume the configuration, so I didn't bother (I'm just going to add max width as an extra arg for now).
