### PR TITLE
builtins/vale: allow per directory configuration override

### DIFF
--- a/lua/null-ls/builtins/diagnostics/vale.lua
+++ b/lua/null-ls/builtins/diagnostics/vale.lua
@@ -20,6 +20,9 @@ return h.make_builtin({
         command = "vale",
         format = "json",
         to_stdin = true,
+        cwd = function(params)
+            return vim.fn.fnamemodify(params.bufname, ":h")
+        end,
         args = function(params)
             return { "--no-exit", "--output", "JSON", "--ext", "." .. vim.fn.fnamemodify(params.bufname, ":e") }
         end,


### PR DESCRIPTION
Currently the vale builtin gets the cwd for the spawned process from the root directory, e.g.

```
[DEBUG Mon 15 Jul 11:27:58 2024] 
/Users/ian/.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/helpers/generator_factory.lua:329: 
spawning command "vale" 
at /Users/ian/projects/my-project with args { "--no-exit", "--output", "JSON", "--ext", ".md" }
```

When we specify the cwd function for the builtin (as in this PR), we see the process spawning from the directory of the file being processed, e.g. file `foo/bar/my-file.md` (with the change in this PR) we see the debug log

```
[DEBUG Mon 15 Jul 11:28:25 2024]
/Users/ian/.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/helpers/generator_factory.lua:329:
spawning command "vale" 
at /Users/ian/projects/my-project/foo/bar with args { "--no-exit", "--output", "JSON", "--ext", ".md" }
```

This has the effect of vale looking for the vale config in this folder first, e.g. `foo/bar/.vale.ini`, allowing per directory override. If you don't have a per-directory config file and had your `.vale.ini` in the project root (or a ancestor directory) of the root then vale will pick this up as it did before this change. 
