### PR TITLE
fix: add RELPATH to parse_args

### DIFF
--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -26,6 +26,9 @@ local parse_args = function(args, params)
         ["FILENAME"] = function()
             return params.temp_path or params.bufname
         end,
+        ["RELPATH"] = function()
+            return vim.fn.fnamemodify(params.bufname, ":p:.")
+        end,
         ["DIRNAME"] = function()
             return vim.fn.fnamemodify(params.bufname, ":h")
         end,


### PR DESCRIPTION
 to be compatible with cppcheck --file-filter=<path> 

cppcheck by default strips the root path, and it did not seem possible to build that path in any way other than adding this as an option. 

It might be good to be able to allow users to add their own fnamemodify args somehow, but I thought this was a simple and easy fix