### PR TITLE
Ensure item.detail is a string

### DIFF
--- a/lua/null-ls/builtins/completion/luasnip.lua
+++ b/lua/null-ls/builtins/completion/luasnip.lua
@@ -40,6 +40,12 @@ return h.make_builtin({
                             snip_id = snip.id,
                             show_condition = snip.show_condition,
                         }
+                        local detail
+                        if type(snip.detail) == 'table' then
+                            detail = table.concat(snip.detail, "\n")
+                        else
+                            detail = snip.detail
+                        end
                         if not snip.hidden then
                             items[#items + 1] = {
                                 word = snip.trigger,

--- a/lua/null-ls/builtins/completion/luasnip.lua
+++ b/lua/null-ls/builtins/completion/luasnip.lua
@@ -41,7 +41,7 @@ return h.make_builtin({
                             show_condition = snip.show_condition,
                         }
                         local detail
-                        if type(snip.detail) == 'table' then
+                        if type(snip.detail) == "table" then
                             detail = table.concat(snip.detail, "\n")
                         else
                             detail = snip.detail

--- a/lua/null-ls/builtins/completion/luasnip.lua
+++ b/lua/null-ls/builtins/completion/luasnip.lua
@@ -50,7 +50,7 @@ return h.make_builtin({
                             items[#items + 1] = {
                                 word = snip.trigger,
                                 label = snip.trigger,
-                                detail = snip.description,
+                                detail = detail,
                                 kind = vim.lsp.protocol.CompletionItemKind.Snippet,
                                 data = data,
                                 documentation = {


### PR DESCRIPTION
luasnip returns the description as a table. For example the following luasnippet

```
  s({
      trig ="test",
      name = "Testing Snippet",
      dscr = "This descriptions breaks cmp",
    },
    fmta(
      [[
        Testing <snippets>
      ]], {
      snippets = i(0),
  })),

```

The completion item detail is created as a table

```
{
  data = {
    filetype = "lua",
    ft_indx = 2,
    show_condition = <function 1>,
    snip_id = 1,
    type = "luasnip"
  },
  detail = { "This descriptions breaks cmp" },
  documentation = {
    kind = "markdown",
    value = "Testing Snippet _ `[lua]`\n---\nThis descriptions breaks cmp\n```lua\nTesting $0\n```"
  },
  kind = 15,
  label = "test",
  word = "test"
}

```

This breaks `hrsh7th/nvim-cmp` that expects this value to be a string. With this change completions are created without errors.