### PR TITLE
fix: add `.{NAME}rc.mjs` to cosmiconfig file patterns

### DIFF
--- a/lua/null-ls/utils/cosmiconfig.lua
+++ b/lua/null-ls/utils/cosmiconfig.lua
@@ -12,6 +12,7 @@ return function(module_name, pkg_json_field_name)
         ".{NAME}rc.yml",
         ".{NAME}rc.js",
         ".{NAME}rc.ts",
+        ".{NAME}rc.mjs",
         ".{NAME}rc.cjs",
         "{NAME}.config.js",
         "{NAME}.config.ts",


### PR DESCRIPTION
Cosmiconfig will check `.{NAME}rc.mjs`, but none-ls ignores them.

https://github.com/cosmiconfig/cosmiconfig