### PR TITLE
builtins/formatting: allow treefmt to run without config

### DIFF
--- a/lua/null-ls/builtins/formatting/treefmt.lua
+++ b/lua/null-ls/builtins/formatting/treefmt.lua
@@ -15,10 +15,6 @@ return h.make_builtin({
         command = "treefmt",
         args = { "--allow-missing-formatter", "--stdin", "$FILENAME" },
         to_stdin = true,
-        -- treefmt requires a config file
-        condition = function(utils)
-            return utils.root_has_file("treefmt.toml")
-        end,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
this allows running treefmt in a projects which are managed by treefmt-nix.

There should be no downsides to running treefmt if it returns an error anyway and treefmt-nix creates a treefmt wrapper (if the wrapper is included in the devshell) which inlines the config. This makes it possible to use none-ls in with direnv and treefmt-nix to have automatic formatting for all the languages defined in the flake.nix