### PR TITLE
feat: add treefmt_nix to builtins

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3881,6 +3881,10 @@ local sources = { null_ls.builtins.formatting.topiary }
 
 One CLI to format your repo
 
+### [treefmt_nix](https://github.com/numtide/treefmt-nix)
+
+Fast and convenient multi-file formatting with Nix
+
 #### Usage
 
 ```lua

--- a/doc/builtins.json
+++ b/doc/builtins.json
@@ -1180,6 +1180,9 @@
     "treefmt": {
       "filetypes": []
     },
+    "treefmt_nix": {
+      "filetypes": []
+    },
     "typstfmt": {
       "filetypes": [
         "typ",

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -346,6 +346,9 @@ return {
   treefmt = {
     filetypes = {}
   },
+  treefmt_nix = {
+    filetypes = {}
+  },
   typstfmt = {
     filetypes = { "typ", "typst" }
   },

--- a/lua/null-ls/builtins/formatting/treefmt_nix.lua
+++ b/lua/null-ls/builtins/formatting/treefmt_nix.lua
@@ -1,0 +1,24 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "treefmt",
+    meta = {
+        url = "https://github.com/numtide/treefmt-nix",
+        description = "Fast and convenient multi-file formatting with Nix",
+    },
+    method = FORMATTING,
+    filetypes = {},
+    generator_opts = {
+        command = "treefmt-nix",
+        args = { "--allow-missing-formatter", "--stdin", "$FILENAME" },
+        to_stdin = true,
+        -- treefmt-nix wrapper needs to be available
+    },
+    condition = function(utils)
+        return utils.is_executable("treefmt-nix")
+    end,
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
depends on https://github.com/numtide/treefmt-nix/pull/243

not sure if there is a policy before creating a builtin. but I didn't want to break usage with the treefmt plugin. treefmt-nix allows configuring treefmt with nix and there is an optional wrapper that can be included in a devshell. this builtin is expected to be used together with devenv and the treefmt-nix wrapper inside the devshell.

@Mic92 maybe has some feedback on this approach :)