### PR TITLE
Fix broken conditions

### DIFF
--- a/lua/null-ls/builtins/formatting/cbfmt.lua
+++ b/lua/null-ls/builtins/formatting/cbfmt.lua
@@ -19,10 +19,10 @@ return h.make_builtin({
             "--best-effort",
         },
         to_stdin = true,
-        -- cbfmt requires a config file
-        condition = function(utils)
-            return utils.root_has_file(".cbfmt.toml")
-        end,
     },
+    -- cbfmt requires a config file
+    condition = function(utils)
+        return utils.root_has_file(".cbfmt.toml")
+    end,
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/treefmt.lua
+++ b/lua/null-ls/builtins/formatting/treefmt.lua
@@ -15,10 +15,10 @@ return h.make_builtin({
         command = "treefmt",
         args = { "--allow-missing-formatter", "--stdin", "$FILENAME" },
         to_stdin = true,
-        -- treefmt requires a config file
-        condition = function(utils)
-            return utils.root_has_file("treefmt.toml")
-        end,
     },
+    -- treefmt requires a config file
+    condition = function(utils)
+        return utils.root_has_file("treefmt.toml")
+    end,
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
`condition` isn't used by `generator_opts`. I believe it used to be, but that was removed in
<https://github.com/nvimtools/none-ls.nvim/commit/ef4eae66de5a90e0ca9cbeac90001064427ce763>.

The fix is simple: just pass this directly to `make_builtin`, [it's a real
option](https://github.com/nvimtools/none-ls.nvim/blob/ae1cffae6d8defb1930028ad5a58f912e14a61e2/lua/null-ls/helpers/make_builtin.lua#L11).