### PR TITLE
feature: clear cache when stopping lsp client

### DIFF
--- a/lua/null-ls/helpers/cache.lua
+++ b/lua/null-ls/helpers/cache.lua
@@ -2,7 +2,11 @@ local next_key = 0
 
 local M = {}
 
-M.cache = {}
+M._reset = function()
+    M.cache = {}
+end
+
+M._reset()
 
 --- creates a function that caches the output of a callback, indexed by bufnr
 ---@param cb function
@@ -10,11 +14,15 @@ M.cache = {}
 M.by_bufnr = function(cb)
     -- assign next available key, since we just want to avoid collisions
     local key = next_key
-    M.cache[key] = {}
     next_key = next_key + 1
 
     return function(params)
         local bufnr = params.bufnr
+
+        if M.cache[key] == nil then
+            M.cache[key] = {}
+        end
+
         -- if we haven't cached a value yet, get it from cb
         if M.cache[key][bufnr] == nil then
             -- make sure we always store a value so we know we've already called cb
@@ -23,10 +31,6 @@ M.by_bufnr = function(cb)
 
         return M.cache[key][bufnr]
     end
-end
-
-M._reset = function()
-    M.cache = {}
 end
 
 return M

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -1,6 +1,7 @@
 local c = require("null-ls.config")
 local log = require("null-ls.logger")
 local methods = require("null-ls.methods")
+local cache = require("null-ls.helpers").cache
 
 local notification_cache = {}
 
@@ -139,6 +140,7 @@ M.start = function(dispatchers)
             return stopped
         end,
         terminate = function()
+            cache._reset()
             stopped = true
         end,
     }


### PR DESCRIPTION
This completes <https://github.com/nvimtools/none-ls.nvim/issues/198>. The only tricky bit was that our cache helpers can no longer assume their key is present in the cache (as the cache can get reset).

I could have done this with a Lua metatable with a default value instead. Please let me know if you'd prefer that approach!