### PR TITLE
builtins/erblint: update cmd to erb_lint

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -706,7 +706,7 @@ local sources = { null_ls.builtins.diagnostics.erb_lint }
 
 - Filetypes: `{ "eruby" }`
 - Method: `diagnostics`
-- Command: `erblint`
+- Command: `erb_lint`
 - Args: `{ "--format", "json", "--stdin", "$FILENAME" }`
 
 ### [fish](https://github.com/fish-shell/fish-shell)
@@ -2444,7 +2444,7 @@ local sources = { null_ls.builtins.formatting.erb_lint }
 
 - Filetypes: `{ "eruby" }`
 - Method: `formatting`
-- Command: `erblint`
+- Command: `erb_lint`
 - Args: `{ "--autocorrect", "--stdin", "$FILENAME" }`
 
 ### [erlfmt](https://github.com/WhatsApp/erlfmt)

--- a/lua/null-ls/builtins/diagnostics/erb_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/erb_lint.lua
@@ -37,7 +37,7 @@ return h.make_builtin({
     method = DIAGNOSTICS,
     filetypes = { "eruby" },
     generator_opts = {
-        command = "erblint",
+        command = "erb_lint",
         args = { "--format", "json", "--stdin", "$FILENAME" },
         to_stdin = true,
         format = "json",

--- a/lua/null-ls/builtins/formatting/erb_lint.lua
+++ b/lua/null-ls/builtins/formatting/erb_lint.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = { "eruby" },
     factory = h.generator_factory,
     generator_opts = {
-        command = "erblint",
+        command = "erb_lint",
         args = { "--autocorrect", "--stdin", "$FILENAME" },
         ignore_stderr = true,
         to_stdin = true,


### PR DESCRIPTION
Beginning with version 0.7.0, the new executable command is `erb_lint`.
