### PR TITLE
builtins/formatting: add duster

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3194,6 +3194,23 @@ local sources = { null_ls.builtins.formatting.pint }
 - Command: `pint`
 - Args: `{ "--no-interaction", "--quiet", "$FILENAME" }`
 
+### [duster](https://github.com/tighten/duster)
+
+Automatic configuration for Laravel apps to apply Tighten's standard linting & code standards.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.duster }
+```
+
+#### Defaults
+
+- Filetypes: `{ "php" }`
+- Method: `formatting`
+- Command: `duster`
+- Args: `{ "fix", "$FILENAME", "--no-interaction", "--quiet" }`
+
 ### [prettier](https://github.com/prettier/prettier)
 
 Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.

--- a/lua/null-ls/builtins/formatting/duster.lua
+++ b/lua/null-ls/builtins/formatting/duster.lua
@@ -1,0 +1,30 @@
+local h = require("null-ls.helpers")
+local u = require("null-ls.utils")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "duster",
+    meta = {
+        url = "https://github.com/tighten/duster",
+        description = "Automatic configuration for Laravel apps to apply Tighten's standard linting & code standards.",
+    },
+    method = FORMATTING,
+    filetypes = { "php" },
+    generator_opts = {
+        command = vim.fn.executable("./vendor/bin/duster") == 1 and "./vendor/bin/duster" or "duster",
+        args = {
+            "fix",
+            "$FILENAME",
+            "--no-interaction",
+            "--quiet",
+        },
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern("duster.json", "composer.json", "composer.lock")(params.bufname)
+        end),
+        to_stdin = true,
+        to_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
[Duster](https://github.com/tighten/duster) combines different PHP formatters and linters and runs them all simultaneously. It should work similarly to [Pint](https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/formatting/pint.lua), [PHPCS](https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/formatting/phpcbf.lua), or [PHP-CS-Fixer](https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/formatting/phpcsfixer.lua) (since it wraps those packages).