### PR TITLE
fix "error executing lua callback ... attempt to concatenate local 'method' (a table value)"

### DIFF
--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -103,7 +103,7 @@ M.start = function(dispatchers)
     end
 
     local function request(method, params, callback, notify_callback)
-        log:trace("received LSP request for method " .. method)
+        log:trace("received LSP request for method " .. vim.inspect(method))
 
         -- clear pending requests from client object
         local success = handle(method, params, callback)
@@ -128,7 +128,7 @@ M.start = function(dispatchers)
             clear_cache(params)
         end
 
-        log:trace("received LSP notification for method " .. method)
+        log:trace("received LSP notification for method " .. vim.inspect(method))
         return handle(method, params, nil, true)
     end
 


### PR DESCRIPTION
After updating my plugins I his this error, while editing a shell script.  Other LSPs seem to work fine.

```
Error detected while processing InsertLeave Autocommands for "*":
Error executing lua callback: .../.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/rpc.lua:131: attempt to concatenate local 'method' (a table value)
stack traceback:
        .../.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/rpc.lua:131: in function 'notify'
        ...art/usr/neovim/share/nvim/runtime/lua/vim/lsp/client.lua:784: in function 'notify'
        ...ocal/share/nvim/lazy/none-ls.nvim/lua/null-ls/client.lua:205: in function 'notify_client'
        .../.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/rpc.lua:149: in function 'flush'
        ....local/share/nvim/lazy/none-ls.nvim/lua/null-ls/init.lua:49: in function <....local/share/nvim/lazy/none-ls.nvim/lua/null-ls/init.lua:48>
```

It would seem that the `method` passed to `dispatchers.notify()` method is a table, not a string.

I have used `vim.inspect(method)` to convert that `method` table to a string before concatenation.

Problem went away, LSP working fine in bash.