### PR TITLE
builtins: add sqruff

### DIFF
--- a/doc/builtins.json
+++ b/doc/builtins.json
@@ -1120,6 +1120,11 @@
         "sql"
       ]
     },
+    "sqruff": {
+      "filetypes": [
+        "sql"
+      ]
+    },
     "stylelint": {
       "filetypes": [
         "scss",

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -380,8 +380,8 @@ return {
     diagnostics = { "rpmspec" }
   },
   sql = {
-    diagnostics = { "sqlfluff" },
-    formatting = { "pg_format", "sql_formatter", "sqlfluff", "sqlfmt", "sqlformat" }
+    diagnostics = { "sqlfluff", "sqruff" },
+    formatting = { "pg_format", "sql_formatter", "sqlfluff", "sqlfmt", "sqlformat", "sqruff" }
   },
   stylus = {
     diagnostics = { "stylint" }

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -310,6 +310,9 @@ return {
   sqlformat = {
     filetypes = { "sql" }
   },
+  sqruff = {
+    filetypes = { "sql" }
+  },
   stylelint = {
     filetypes = { "scss", "less", "css", "sass" }
   },

--- a/lua/null-ls/builtins/diagnostics/sqruff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqruff.lua
@@ -1,0 +1,38 @@
+local null_ls = require("null-ls")
+local helpers = require("null-ls.helpers")
+
+return helpers.make_builtin({
+    name = "sqruff",
+    meta = {
+        url = "https://github.com/quarylabs/sqruff",
+        description = "A high-speed SQL linter written in Rust.",
+    },
+    method = null_ls.methods.DIAGNOSTICS,
+    filetypes = { "sql" },
+    factory = helpers.generator_factory,
+    generator_opts = {
+        command = "sqruff",
+        args = {
+            "lint",
+            "--format",
+            "github-annotation-native",
+            "$FILENAME",
+        },
+        from_stderr = true,
+        to_stdin = false,
+        to_temp_file = true,
+        format = "line",
+        check_exit_code = function(c)
+            return c <= 1
+        end,
+        on_output = helpers.diagnostics.from_pattern(
+            [[^::(%w+) .*,file=(.*),line=(%d+),col=(%d+)::(%w+: .*)]],
+            { "severity", "filename", "row", "col", "message" },
+            {
+                severities = {
+                    ["error"] = helpers.diagnostics.severities.error,
+                },
+            }
+        ),
+    },
+})

--- a/lua/null-ls/builtins/formatting/sqruff.lua
+++ b/lua/null-ls/builtins/formatting/sqruff.lua
@@ -1,0 +1,24 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "sqruff",
+    meta = {
+        url = "https://github.com/quarylabs/sqruff",
+        description = "A high-speed SQL linter written in Rust.",
+    },
+    method = FORMATTING,
+    filetypes = { "sql" },
+    generator_opts = {
+        command = "sqruff",
+        args = {
+            "fix",
+            "-",
+        },
+        from_stdin = true,
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Add support for `sqruff` diagnostics, and formatting.
