### PR TITLE
helpers: run `dynamic_command` immediately when opening a buffer

### DIFF
--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -106,10 +106,17 @@ directory defaults to the project's root.
 ### dynamic_command
 
 Optional callback to set `command` dynamically. Takes two arguments, a `params`
-table and a `done` callback. The generator's original command (if set) is
-available as `params.command`. The `done` callback should be invoked with a
-string containing the command to run or `nil`, meaning that no command should
-run.
+table and a `done` callback.
+
+`params` is a table with the following keys:
+
+- `bufnr`
+- `bufname`
+- `root`
+- `command`: The generator's original command (if set)
+
+The `done` callback should be invoked with a string containing the command to
+run or `nil`, meaning that no command should run.
 
 `dynamic_command` runs every time its parent generator runs and can affect
 performance, so it's best to cache its output when possible.
@@ -281,6 +288,7 @@ helpers.make_builtin({
     factory, -- function (optional)
     filetypes, -- table
     generator, -- function (optional, but required if factory is not set)
+    setup_buffer_async, -- function (optional)
     generator_opts, -- table
     method, -- internal null-ls method (string)
     meta, -- table

--- a/lua/null-ls/builtins/_test/dynamic_command_code_action.lua
+++ b/lua/null-ls/builtins/_test/dynamic_command_code_action.lua
@@ -1,0 +1,27 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local CODE_ACTION = methods.internal.CODE_ACTION
+
+return h.make_builtin({
+    method = CODE_ACTION,
+    filetypes = { "text" },
+    generator_opts = {
+        on_output = function(_params, done)
+            return done({
+                {
+                    title = "an action",
+                    action = function() end,
+                },
+            })
+        end,
+    },
+    factory = function(opts)
+        opts._dynamic_command_call_count = 0
+        opts.dynamic_command = function(_params, done)
+            opts._dynamic_command_call_count = opts._dynamic_command_call_count + 1
+            done("ls")
+        end
+        return h.generator_factory(opts)
+    end,
+})

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -173,6 +173,17 @@ M.setup_buffer = function(bufnr)
         return
     end
 
+    -- Notify each generator for this filetype. This gives them a chance to
+    -- precompute information.
+    local filetype = api.nvim_get_option_value("filetype", { buf = bufnr })
+    for _, source in ipairs(require("null-ls.sources").get({ filetype = filetype })) do
+        if source.generator.setup_buffer_async then
+            source.generator.setup_buffer_async(bufnr, function()
+                -- Nothing to do here.
+            end)
+        end
+    end
+
     local on_attach = c.get().on_attach
     if on_attach then
         on_attach(client, bufnr)

--- a/lua/null-ls/helpers/cache.lua
+++ b/lua/null-ls/helpers/cache.lua
@@ -8,9 +8,13 @@ end
 
 M._reset()
 
+---@class NullLsCacheParams
+---@field bufnr number
+---@field root string
+
 --- creates a function that caches the output of a callback, indexed by bufnr
 ---@param cb function
----@return fun(params: NullLsParams): any
+---@return fun(params: NullLsCacheParams): any
 M.by_bufnr = function(cb)
     -- assign next available key, since we just want to avoid collisions
     local key = next_key
@@ -35,7 +39,7 @@ end
 
 --- creates a function that caches the output of an async callback, indexed by bufnr
 ---@param cb function
----@return fun(params: NullLsParams): any
+---@return fun(params: NullLsCacheParams): any
 M.by_bufnr_async = function(cb)
     -- assign next available key, since we just want to avoid collisions
     local key = next_key

--- a/lua/null-ls/helpers/command_resolver.lua
+++ b/lua/null-ls/helpers/command_resolver.lua
@@ -29,8 +29,7 @@ end
 --- creates a resolver that searches for a local executable and caches results by bufnr
 ---@param prefix string|nil
 M.generic = function(prefix)
-    ---@param params NullLsParams
-    ---@return string|nil
+    ---@param params NullLsDynamicCommandParams
     return cache.by_bufnr_async(function(params, done)
         local executable_to_find = prefix and u.path.join(prefix, params.command) or params.command
         if not executable_to_find then

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -613,19 +613,15 @@ describe("e2e", function()
     end)
 
     describe("dynamic_command", function()
-        it("should run each time we need a command", function()
+        it("should run immediately, plus each time we need a command", function()
             local source = builtins._test.dynamic_command_code_action
             sources.register(source)
             tu.edit_test_file("test-file.txt")
             tu.wait()
 
-            -- Make sure we haven't run `dynamic_command` yet.
-            assert.equals(0, source._opts._dynamic_command_call_count)
-
-            -- Query for code actions, make sure we've run `dynamic_command` once.
-            local actions = get_code_actions()
-            tu.wait()
-            assert.equals("ls", source._opts._last_command)
+            -- Make sure we already ran `dynamic_command` once, even though we haven't needed it yet.
+            -- This allows generators to pre-compute `dynamic_command` if it's
+            -- time consuming to compute.
             assert.equals(1, source._opts._dynamic_command_call_count)
 
             -- Query for code actions, make sure we've run `dynamic_command` twice.
@@ -633,6 +629,12 @@ describe("e2e", function()
             tu.wait()
             assert.equals("ls", source._opts._last_command)
             assert.equals(2, source._opts._dynamic_command_call_count)
+
+            -- Query for code actions, make sure we've run `dynamic_command` thrice.
+            local actions = get_code_actions()
+            tu.wait()
+            assert.equals("ls", source._opts._last_command)
+            assert.equals(3, source._opts._dynamic_command_call_count)
         end)
     end)
 

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -612,6 +612,30 @@ describe("e2e", function()
         end)
     end)
 
+    describe("dynamic_command", function()
+        it("should run each time we need a command", function()
+            local source = builtins._test.dynamic_command_code_action
+            sources.register(source)
+            tu.edit_test_file("test-file.txt")
+            tu.wait()
+
+            -- Make sure we haven't run `dynamic_command` yet.
+            assert.equals(0, source._opts._dynamic_command_call_count)
+
+            -- Query for code actions, make sure we've run `dynamic_command` once.
+            local actions = get_code_actions()
+            tu.wait()
+            assert.equals("ls", source._opts._last_command)
+            assert.equals(1, source._opts._dynamic_command_call_count)
+
+            -- Query for code actions, make sure we've run `dynamic_command` twice.
+            local actions = get_code_actions()
+            tu.wait()
+            assert.equals("ls", source._opts._last_command)
+            assert.equals(2, source._opts._dynamic_command_call_count)
+        end)
+    end)
+
     -- https://github.com/neovim/neovim/commit/8260e4860b27a54a061bd8e2a9da23069993953a
     -- hover no longer supports handler
     if not vim.fn.has("nvim-0.11") == 1 then


### PR DESCRIPTION
This allows generators to pre-compute `dynamic_command` if it's
time consuming to compute.

This completes https://github.com/nvimtools/none-ls.nvim/issues/218

I implemented this in 2 commits, I recommend reading them independently.