### PR TITLE
fix(#217): only 0.10 required for :supports_method syntax

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -75,7 +75,7 @@ local on_init = function(new_client, initialize_result)
         return methods.lsp[method] ~= nil
     end
 
-    if vim.fn.has("nvim-0.11") == 1 then
+    if vim.fn.has("nvim-0.10.3") == 1 then
         new_client.supports_method = function(_, method)
             return supports_method(method)
         end


### PR DESCRIPTION
On my neovim `0.10`, the `client:supports_method` syntax is supported. `none-ls`, however, specifies `vim.fn.has(0.11)`.

Changing the version to `0.10` fixes this compatibility issue, as well as resolves all of the initial issues I personally had on #217.