### PR TITLE
client: dynamically detect method style calls

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -9,6 +9,28 @@ local loop = require("null-ls.loop")
 local api = vim.api
 local lsp = vim.lsp
 
+-- Inspired by upstream neovim:
+-- <https://github.com/neovim/neovim/blob/43d552c56648bc3125c7509b3d708b6bf6c0c09c/runtime/lua/vim/lsp/client.lua#L234-L249>.
+-- This can go away sometime after neovim drops support for the legacy way
+-- of invoking these functions.
+-- Alternatively, we could get out of the business of monkeypatching Neovim
+-- functions, see <https://github.com/nvimtools/none-ls.nvim/discussions/229>.
+--- @param obj table<string,any>
+--- @param cls table<string,function>
+--- @param name string
+local function method_wrapper(obj, cls, name)
+    local func = assert(obj[name], "couldn't find " .. name .. " function")
+    obj[name] = function(maybe_self, ...)
+        if maybe_self and getmetatable(maybe_self) == cls then
+            -- First argument is self. Drop it and call `func` directly.
+            return func(...)
+        end
+        vim.deprecate("client." .. name, "client:" .. name, "0.13")
+        -- First argument is not self, include it when calling `func`.
+        return func(maybe_self, ...)
+    end
+end
+
 ---@type vim.lsp.Client?, integer?
 local client, id
 
@@ -75,12 +97,9 @@ local on_init = function(new_client, initialize_result)
         return methods.lsp[method] ~= nil
     end
 
+    new_client.supports_method = supports_method
     if vim.fn.has("nvim-0.11") == 1 then
-        new_client.supports_method = function(_, method)
-            return supports_method(method)
-        end
-    else
-        new_client.supports_method = supports_method
+        method_wrapper(new_client, vim.lsp.client, "supports_method")
     end
 
     if c.get().on_init then

--- a/test/spec/client_spec.lua
+++ b/test/spec/client_spec.lua
@@ -24,6 +24,7 @@ describe("client", function()
             resolved_capabilities = {},
             server_capabilities = {},
         }
+        setmetatable(mock_client, vim.lsp.client)
         lsp.start_client.returns(mock_client_id)
         sources.get_filetypes.returns(mock_filetypes)
     end)
@@ -130,6 +131,16 @@ describe("client", function()
                     assert.stub(can_run).was_called_with(vim.bo.filetype, methods.internal.CODE_ACTION)
                     assert.equals(is_supported, true)
                 end)
+
+                if vim.fn.has("nvim-0.11") == 1 then
+                    it("can still use legacy . syntax", function()
+                        can_run.returns(true)
+                        local is_supported = mock_client.supports_method(methods.lsp.CODE_ACTION)
+
+                        assert.stub(can_run).was_called_with(vim.bo.filetype, methods.internal.CODE_ACTION)
+                        assert.equals(is_supported, true)
+                    end)
+                end
 
                 it("should return result of methods.is_supported if no corresponding internal method", function()
                     local is_supported = supports_method(methods.lsp.SHUTDOWN)


### PR DESCRIPTION
Neovim is moving towards dropping the old function style (`.`) of invoking these in favor of method style (`:`). We added support for that in
https://github.com/nvimtools/none-ls.nvim/commit/94d024e6550e53c70c3ab765c476a0158b65f564, but it's not perfect: it incorrectly assumes that if you're using nvim-0.11 then *all* invocations of these helpers are method style. I imagine that's true for core-neovim, but there are still plugins in the ecosystem using `.` style. For example, see
<https://github.com/lukas-reineke/lsp-format.nvim/blob/v2.7.1/lua/lsp-format/init.lua#L260>, which I use with Neovim nightly.