### PR TITLE
fix(logger): schedule vim.notify

### DIFF
--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -80,14 +80,18 @@ end
 ---@param msg any
 function log:warn(msg)
     self:add_entry(msg, "warn")
-    vim.notify(self.__notify_fmt(msg), vim.log.levels.WARN, default_notify_opts)
+    vim.schedule(function()
+        vim.notify(self.__notify_fmt(msg), vim.log.levels.WARN, default_notify_opts)
+    end)
 end
 
 ---Add a log entry at ERROR level
 ---@param msg any
 function log:error(msg)
     self:add_entry(msg, "error")
-    vim.notify(self.__notify_fmt(msg), vim.log.levels.ERROR, default_notify_opts)
+    vim.schedule(function()
+        vim.notify(self.__notify_fmt(msg), vim.log.levels.ERROR, default_notify_opts)
+    end)
 end
 
 setmetatable({}, log)

--- a/test/spec/builtins/diagnostics/regal_spec.lua
+++ b/test/spec/builtins/diagnostics/regal_spec.lua
@@ -7,6 +7,10 @@ stub(vim, "notify")
 describe("diagnostics regal", function()
     local parser = diagnostics.regal._opts.on_output
 
+    local wait_for_scheduler = function()
+        vim.wait(0)
+    end
+
     it("should create a diagnostic with error severity", function()
         local output = vim.json.decode([[
           {
@@ -62,6 +66,7 @@ describe("diagnostics regal", function()
     it("should log error for non-json output", function()
         local diagnostic = parser({ output = "non-json-output", err = "json error" })
         assert.same({}, diagnostic)
+        wait_for_scheduler()
         assert
             .stub(vim.notify)
             .was_called_with("[null-ls] non-json-output", vim.log.levels.ERROR, { title = "null-ls" })


### PR DESCRIPTION
Since https://github.com/neovim/neovim/pull/31900 it's using `nvim_echo` which cannot be called in fast mode.