### PR TITLE
fix(docs): add missing `plenary.nvim` plugin

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install Neovim plugins
         run: |
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
           git clone --depth 1 https://github.com/ibhagwan/ts-vimdoc.nvim ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim
           git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/vendor/start/nvim-treesitter
 


### PR DESCRIPTION
This has always been a dependency of none-ls, but now it recently became necessary to build our docs
(this file gets imported during `autogen`, which requires plenary: https://github.com/nvimtools/none-ls.nvim/blob/0143bb5f117f76863cf0c24bcf0724d3137f04d2/lua/null-ls/builtins/formatting/nix_flake_fmt.lua#L5)