### PR TITLE
utils: use non-deprecated vim.validate form for Nvim 0.11

### DIFF
--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -1,6 +1,6 @@
 local u = require("null-ls.utils")
 
-local validate = vim.validate
+local validate = u.validate
 
 local defaults = {
     cmd = { "nvim" },

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -4,7 +4,7 @@ local methods = require("null-ls.methods")
 local s = require("null-ls.state")
 local u = require("null-ls.utils")
 
-local validate = vim.validate
+local validate = u.validate
 
 local registered = {
     names = {},

--- a/lua/null-ls/utils/init.lua
+++ b/lua/null-ls/utils/init.lua
@@ -370,4 +370,15 @@ M.get_vcs_root = function()
     return vcs_root
 end
 
+M.validate = function(validators)
+    if vim.fn.has("nvim-0.11.0") ~= 1 then
+        vim.validate(validators)
+        return
+    end
+
+    for vname, spec in pairs(validators) do
+        vim.validate(vname, spec[1], spec[2], spec[3])
+    end
+end
+
 return M


### PR DESCRIPTION
`:checkhealth vim.deprecated` complained about it.