### PR TITLE
feat(builtins): Add cljfmt formatter for clojure code

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2201,6 +2201,23 @@ local sources = { null_ls.builtins.formatting.clang_format }
 - Command: `clang-format`
 - Args: dynamically resolved (see [source](https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/formatting/clang_format.lua))
 
+### [cljfmt](https://github.com/weavejester/cljfmt)
+
+A tool for formatting Clojure code
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.cljfmt }
+```
+
+#### Defaults
+
+- Filetypes: `{ "clojure" }`
+- Method: `formatting`
+- Command: `cljfmt`
+- Args: `{ "fix", "-" }`
+
 ### [cljstyle](https://github.com/greglook/cljstyle)
 
 Formatter for Clojure code.

--- a/doc/builtins.json
+++ b/doc/builtins.json
@@ -643,6 +643,11 @@
         "proto"
       ]
     },
+    "cljfmt": {
+      "filetypes": [
+        "clojure"
+      ]
+    },
     "cljstyle": {
       "filetypes": [
         "clojure"

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -74,7 +74,7 @@ return {
   },
   clojure = {
     diagnostics = { "clj_kondo" },
-    formatting = { "cljstyle", "zprint" }
+    formatting = { "cljfmt", "cljstyle", "zprint" }
   },
   cmake = {
     diagnostics = { "cmake_lint" },

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -46,6 +46,9 @@ return {
   clang_format = {
     filetypes = { "c", "cpp", "cs", "java", "cuda", "proto" }
   },
+  cljfmt = {
+    filetypes = { "clojure" }
+  },
   cljstyle = {
     filetypes = { "clojure" }
   },

--- a/lua/null-ls/builtins/formatting/cljfmt.lua
+++ b/lua/null-ls/builtins/formatting/cljfmt.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "cljfmt",
+    meta = {
+        url = "https://github.com/weavejester/cljfmt",
+        description = "A tool for formatting Clojure code",
+    },
+    method = FORMATTING,
+    filetypes = { "clojure" },
+    generator_opts = {
+        command = "cljfmt",
+        args = { "fix", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
This adds cljfmt in addition to the existing ones. It is a really popular formatter in the community and it would be great to have it available.