### PR TITLE
fix: adapt to LSP capability mapping change

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -74,7 +74,9 @@ end
 local on_init = function(new_client, initialize_result)
     local capability_is_disabled = function(method)
         -- TODO: extract map to prevent future issues
-        local required_capability = lsp._request_name_to_capability[method]
+        local method_to_required_capability_map = lsp.protocol._request_name_to_capability
+            or lsp._request_name_to_capability
+        local required_capability = method_to_required_capability_map[method]
         return not required_capability
             or vim.tbl_get(new_client.server_capabilities, unpack(required_capability)) == false
     end


### PR DESCRIPTION
Addresses recent breaking change introduced in PR #32503, where the
internal mapping table `_request_name_to_capability` was moved from
`vim.lsp` to `vim.lsp.protocol`.

See [PR #32503](https://github.com/neovim/neovim/pull/32503)

This change ensures compatibility with both older and newer versions
by checking both locations for the mapping table. It uses a fallback
mechanism for locating the mapping, accommodating the API change.

Fixes #252
