### PR TITLE
fix: adapt to breaking change

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -74,7 +74,7 @@ end
 local on_init = function(new_client, initialize_result)
     local capability_is_disabled = function(method)
         -- TODO: extract map to prevent future issues
-        local required_capability = lsp._request_name_to_capability[method]
+        local required_capability = lsp.protocol._request_name_to_capability[method]
         return not required_capability
             or vim.tbl_get(new_client.server_capabilities, unpack(required_capability)) == false
     end


### PR DESCRIPTION
Since
https://github.com/neovim/neovim/commit/e4c1f6667b146cfe33df49e5c5984d4d303c5aec, `_request_name_to_capability` is now inside `.protocol`