### PR TITLE
fix: fix _request_name_to_capability location on neovim 0.11+

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -74,7 +74,8 @@ end
 local on_init = function(new_client, initialize_result)
     local capability_is_disabled = function(method)
         -- TODO: extract map to prevent future issues
-        local required_capability = lsp._request_name_to_capability[method]
+        local map = lsp._request_name_to_capability or lsp.protocol._request_name_to_capability
+        local required_capability = map[method]
         return not required_capability
             or vim.tbl_get(new_client.server_capabilities, unpack(required_capability)) == false
     end


### PR DESCRIPTION
This map location got changed recently in this commit: https://github.com/neovim/neovim/commit/e4c1f6667b146cfe33df49e5c5984d4d303c5aec