### PR TITLE
fix: correctly calculate unicode line length

### DIFF
--- a/lua/null-ls/helpers/diagnostics.lua
+++ b/lua/null-ls/helpers/diagnostics.lua
@@ -74,7 +74,7 @@ local make_diagnostic = function(entries, defaults, attr_adapters, params, offse
 
         local byte_index_col
         if u.has_version("0.11") then
-            byte_index_col = vim.str_byteindex(content_line, "utf-8", col)
+            byte_index_col = vim.str_byteindex(content_line, "utf-32", col)
         else
             byte_index_col = vim.str_byteindex(content_line, col)
         end

--- a/lua/null-ls/helpers/diagnostics.lua
+++ b/lua/null-ls/helpers/diagnostics.lua
@@ -67,10 +67,18 @@ local make_diagnostic = function(entries, defaults, attr_adapters, params, offse
     -- In order to match the correct range in lines with multi-byte characters,
     -- we need to convert the column number to a byte index.
     -- See: https://github.com/nvimtools/none-ls.nvim/issues/19#issuecomment-1820127436
+    -- and https://github.com/nvimtools/none-ls.nvim/issues/226
     if entries["col"] ~= nil and content_line ~= nil then
         local col = tonumber(entries["col"]) or math.huge
-        col = math.min(col, string.len(content_line))
-        local byte_index_col = vim.str_byteindex(content_line, col)
+        col = math.min(col, vim.fn.strwidth(content_line))
+
+        local byte_index_col
+        if u.has_version("0.11") then
+            byte_index_col = vim.str_byteindex(content_line, "utf-8", col)
+        else
+            byte_index_col = vim.str_byteindex(content_line, col)
+        end
+
         entries["col"] = tostring(byte_index_col)
     end
 


### PR DESCRIPTION
Implements fix described in #226

Also in 0.11, `vim.str_byteindex`'s API was changed to clarify utf-X handling, so I added that version as well behind a `has_version` guard.

As stated in the issue, I am convinced that this is correct, since I haven't encountered any problems while running this fix daily for the last 2 months. However, I am not sure if/how to write tests for this behavior.