### PR TITLE
Fix gccdiag diagnostics for multiple files

### DIFF
--- a/lua/null-ls/builtins/diagnostics/gccdiag.lua
+++ b/lua/null-ls/builtins/diagnostics/gccdiag.lua
@@ -23,10 +23,11 @@ return h.make_builtin({
         to_stdin = false,
         from_stderr = true,
         format = "line",
+        multiple_files = true,
         on_output = h.diagnostics.from_pattern(
             [[^([^:]+):(%d+):(%d+):%s+([^:]+):%s+(.*)$]],
             -- [[(%w+):(%d+):(%d+): (%w+): (.*)]],
-            { "file", "row", "col", "severity", "message" },
+            { "filename", "row", "col", "severity", "message" },
             {
                 severities = {
                     ["fatal error"] = h.diagnostics.severities.error,

--- a/lua/null-ls/helpers/diagnostics.lua
+++ b/lua/null-ls/helpers/diagnostics.lua
@@ -102,7 +102,7 @@ end
 
 --- Parse a linter's output using a regex pattern
 -- @param pattern The regex pattern
--- @param groups The groups defined by the pattern: {"line", "message", "col", ["end_col"], ["code"], ["severity"]}
+-- @param groups The groups defined by the pattern: {"line", "message", "col", ["end_col"], ["code"], ["severity"], ["filename"]}
 -- @param overrides A table providing overrides for {adapters, diagnostic, severities, offsets}
 -- @param overrides.diagnostic An optional table of diagnostic default values
 -- @param overrides.severities An optional table of severity overrides (see default_severities)


### PR DESCRIPTION
- **feat: apply diagnostics by filename in `multiple_files`**

Added this here since maybe other generators may return diagnostics by filename too in the future
