### PR TITLE
feat(builtins): Add golangci-lint v2 support

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -825,7 +825,11 @@ A Go linter aggregator.
 #### Usage
 
 ```lua
-local sources = { null_ls.builtins.diagnostics.golangci_lint }
+local sources = {
+    null_ls.builtins.diagnostics.golangci_lint.with({
+        prefer_local = ".bin", -- look for repo-specific binary to a different major version from what's in your PATH
+    }),
+}
 ```
 
 #### Defaults
@@ -833,7 +837,7 @@ local sources = { null_ls.builtins.diagnostics.golangci_lint }
 - Filetypes: `{ "go" }`
 - Method: `diagnostics_on_save`
 - Command: `golangci-lint`
-- Args: `{ "run", "--fix=false", "--out-format=json" }`
+- Args: `{ "run", "--fix=false", "--out-format=json", "$DIRNAME" }` for v1 or `{ "run", "--fix=false", "--show-stats=false", "--output.json.path=stdout", "$DIRNAME" }` for v2
 
 ### [hadolint](https://github.com/hadolint/hadolint)
 

--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -20,13 +20,40 @@ return h.make_builtin({
         ignore_stderr = true,
         multiple_files = true,
         cwd = h.cache.by_bufnr(function(params)
-            return u.root_pattern("go.mod")(params.bufname)
+            -- find the nearest config and use that directory since v2 defaults to
+            -- "relative-path-mode: cfg" which reports file names relative to
+            -- the directory of the config file
+            local cfg_path_yml = u.root_pattern(".golangci.yml")(params.bufname)
+            if cfg_path_yml then
+                return cfg_path_yml
+            end
+            local cfg_path_yaml = u.root_pattern(".golangci.yaml")(params.bufname)
+            if cfg_path_yaml then
+                return cfg_path_yaml
+            end
+            local cfg_path_toml = u.root_pattern(".golangci.toml")(params.bufname)
+            if cfg_path_toml then
+                return cfg_path_toml
+            end
+            local cfg_path_json = u.root_pattern(".golangci.json")(params.bufname)
+            if cfg_path_json then
+                return cfg_path_json
+            end
+            -- nil defaults to git root
+            return nil
         end),
-        args = {
-            "run",
-            "--fix=false",
-            "--out-format=json",
-        },
+        args = h.cache.by_bufnr(function(params)
+            -- params.command respects prefer_local and only_local options
+            local version = vim.system({ params.command, "version" }, { text = true }):wait().stdout
+            -- from observation the version can be either v2.x.x or 2.x.x
+            -- depending on packaging
+            if version and (version:match("version v2") or version:match("version 2")) then
+                return { "run", "--fix=false", "--show-stats=false", "--output.json.path=stdout", "$DIRNAME" }
+            end
+            -- DIRNAME is the absolute path to the directory of the file being
+            -- linted
+            return { "run", "--fix=false", "--out-format=json", "$DIRNAME" }
+        end),
         format = "json",
         check_exit_code = function(code)
             return code <= 2

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -316,6 +316,9 @@ return function(opts)
                     return done()
                 end
 
+                -- update command so that args might use it
+                params.command = resolved_command
+
                 local resolved_cwd = cwd and cwd(params) or root
                 params.cwd = resolved_cwd
 


### PR DESCRIPTION
Resolves #256

I've tested this with v1 and v2 by creating a linter issue in:

1. File in Go module at git root with `.golangci.yml`
2. File in Go sub_package_ of Go module
3. File in Go sub_module_ with `.golangci.yml` in the in the git root directory
4. File in Go sub_module_ with no `.golangci.yml` in git repo

To use v1 when v2 is installed globally (or vise versa), one can install the preferred version in `.bin` in the git root directory and configure the linter as so:

```lua
null_ls.builtins.diagnostics.golangci_lint.with({
    prefer_local = ".bin",
})
```

I have verified that this works by installing v1 in my path and v2 in `.bin` and a v2 config.

Note that this PR seems to work regardless of the `relative-path-mode` setting the user may configure, since the absolute path of the package is given to `golangci-lint` with `$DIRNAME` and therefore the resulting paths in the JSON output are always absolute (based on my testing).
