### PR TITLE
fix(nix_flake_fmt): handle flakes with a `formatter` package

### DIFF
--- a/lua/null-ls/builtins/formatting/nix_flake_fmt.lua
+++ b/lua/null-ls/builtins/formatting/nix_flake_fmt.lua
@@ -224,7 +224,7 @@ local find_nix_fmt = function(opts, done)
             title = NOTIFICATION_TITLE,
         })
 
-        local _done = function (result)
+        local _done = function(result)
             done(result)
             client.send_progress_notification(NOTIFICATION_TOKEN, {
                 kind = "end",


### PR DESCRIPTION
This fixes a bug with `nix_flake_fmt` where it doesn't handle flakes with a "formatter" package. I also did some refactoring in separate commits keep things clean. I suggest reading the commits independently.

- **refactor(fix nix_flake_fmt): split `find_nix_fmt` into smaller functions**
- **refactor(nix_flake_fmt): pass data as JSON rather than ad-hoc lines**
- **fix(nix_flake_fmt): handle flakes with a `formatter` package**

IMO, this plugin has too much nix specific knowledge in it. I've submitted https://github.com/NixOS/nix/pull/13063 to core nix to add a `nix fmt --print-command` option. That would allow us to delete a lot of code in this PR.