### PR TITLE
fix: change csharpier args

### DIFF
--- a/lua/null-ls/builtins/formatting/csharpier.lua
+++ b/lua/null-ls/builtins/formatting/csharpier.lua
@@ -12,9 +12,11 @@ return h.make_builtin({
     method = FORMATTING,
     filetypes = { "cs" },
     generator_opts = {
-        command = "dotnet-csharpier",
+        command = "csharpier",
         args = {
+            "format",
             "--write-stdout",
+            "$FILENAME",
         },
         to_stdin = true,
     },


### PR DESCRIPTION
Hi, not sure this is necessary.
i use `mason` to install the `csharpier`, however the `dotnet-csharpier` not a correct command. it should use `csharpier`.

I use `vim.lsp.buf.format` to format current file.

Some test:
<img width="856" alt="image" src="https://github.com/user-attachments/assets/7fe7724f-53c7-4b67-a94b-8b951aa3876a" />
<img width="379" alt="image" src="https://github.com/user-attachments/assets/6f40fc85-e94e-42d7-a36d-636cf64b3cd9" />
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/6d70d6b8-b059-4c64-bf7d-8121c52ac596" />
