### PR TITLE
fix(csharpier): switched to new formatting command based on recent csharpier 1.0.0 breaking changes 

### DIFF
--- a/lua/null-ls/builtins/formatting/csharpier.lua
+++ b/lua/null-ls/builtins/formatting/csharpier.lua
@@ -12,8 +12,9 @@ return h.make_builtin({
     method = FORMATTING,
     filetypes = { "cs" },
     generator_opts = {
-        command = "dotnet-csharpier",
+        command = "csharpier",
         args = {
+            "format",
             "--write-stdout",
         },
         to_stdin = true,


### PR DESCRIPTION
see: https://github.com/belav/csharpier/blob/main/CHANGELOG.md#rework-the-cli-to-use-commands-and-arguments-1321