### PR TITLE
fix (client.lua): fixes issue #276

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -74,8 +74,8 @@ end
 local on_init = function(new_client, initialize_result)
     local capability_is_disabled = function(method)
         -- TODO: extract map to prevent future issues
-        local method_to_required_capability_map = lsp.protocol._request_name_to_capability
-            or lsp._request_name_to_capability
+        local method_to_required_capability_map = lsp.protocol._request_name_to_server_capability
+            or lsp._request_name_to_server_capability
         local required_capability = method_to_required_capability_map[method]
         return not required_capability
             or vim.tbl_get(new_client.server_capabilities, unpack(required_capability)) == false

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -74,8 +74,9 @@ end
 local on_init = function(new_client, initialize_result)
     local capability_is_disabled = function(method)
         -- TODO: extract map to prevent future issues
-        local method_to_required_capability_map = lsp.protocol._request_name_to_server_capability
-            or lsp._request_name_to_server_capability
+        local method_to_required_capability_map = lsp.protocol._request_name_to_capability
+            or lsp._request_name_to_capability
+            or lsp.protocol._request_name_to_server_capability
         local required_capability = method_to_required_capability_map[method]
         return not required_capability
             or vim.tbl_get(new_client.server_capabilities, unpack(required_capability)) == false


### PR DESCRIPTION
fixes issue #276

In function `on_init`, tries to get `method_to_required_capability_map` from `lsp.protocol._request_name_to_server_capability` when in neovim nightly.
