### PR TITLE
fix: use stdpath("log") dir to find plenary log

### DIFF
--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -55,7 +55,7 @@ end
 --- Retrieves the path of the logfile
 ---@return string path path of the logfile
 function log:get_path()
-    return u.path.join(vim.fn.stdpath("cache") --[[@as string]], "null-ls.log")
+    return u.path.join(vim.fn.stdpath("log") --[[@as string]], "null-ls.log")
 end
 
 ---Add a log entry at TRACE level

--- a/test/spec/logger_spec.lua
+++ b/test/spec/logger_spec.lua
@@ -2,7 +2,7 @@ local logger = require("null-ls.logger")
 
 describe("logger", function()
     it("get_path should return log file path from cache folder", function()
-        local expected = vim.fn.stdpath("cache") .. "/" .. "null-ls.log"
+        local expected = vim.fn.stdpath("log") .. "/" .. "null-ls.log"
         assert.equals(expected, logger:get_path())
     end)
 end)


### PR DESCRIPTION
The plenary log path changed in this PR: https://github.com/nvim-lua/plenary.nvim/pull/607

Anyone who has updated plenary since Feb 11, 2025 has been sent to the old log file when using `:NullLsLog`.