### PR TITLE
fix(checkstyle)!: remove the "file:" prefix from the artifact URI

### DIFF
--- a/lua/null-ls/builtins/diagnostics/checkstyle.lua
+++ b/lua/null-ls/builtins/diagnostics/checkstyle.lua
@@ -35,6 +35,7 @@ local function handle_checkstyle_output(params)
     for _, result in ipairs(results) do
         for _, location in ipairs(result.locations) do
             local col = location.physicalLocation.region.startColumn
+            local parsedUri = location.physicalLocation.artifactLocation.uri:gsub("^file:", "")
 
             table.insert(output, {
                 row = location.physicalLocation.region.startLine,
@@ -43,7 +44,7 @@ local function handle_checkstyle_output(params)
                 code = result.ruleId,
                 message = result.message.text,
                 severity = h.diagnostics.severities[result.level],
-                filename = location.physicalLocation.artifactLocation.uri,
+                filename = parsedUri,
             })
         end
     end


### PR DESCRIPTION
When the checkstyle source receives a diagnostic back from the checkstyle command, it receives a URI in the format of the following:

```java
{
  // ...
  "results": [
    {
      "level": "error",
      "locations": [
        {
          "physicalLocation": {
            "artifactLocation": {
              "uri": "file:/Users/tahminator/personal/demo/src/main/java/com/example/path/demo/DemoApplication.java"
            },
            "region": {
              "startColumn": 27,
              "startLine": 8
            }
          }
        }
      ],
      "message": {
        "text": "Parameter args should be final."
      },
      "ruleId": "final.parameter"
    }
  ]
  // ...
}
```

But Neovim's diagnostic doesn't support this `file:/` extension, and as a result, will not show the error in the opened buffer at all.

<img width="959" height="1037" alt="image" src="https://github.com/user-attachments/assets/262965aa-59d1-43ec-b24d-ed348464f8d5" />
<p align="center">Should show an error here, but doesn't</p>

If you use a plugin like `trouble.nvim`, you'll be able to see the actual error in the list of all buffer diagnostics like so:

<img width="961" height="312" alt="image" src="https://github.com/user-attachments/assets/2514a0c5-c8aa-420d-8f31-d63d41839893" />

But if you hit `<CR>` on the Checkstyle diagnostic, we will open an empty buffer while  throws an error that `Cursor position outside buffer`:

<img width="1919" height="1041" alt="image" src="https://github.com/user-attachments/assets/c39a3e39-f450-4e70-9b48-3ae913df9315" />

I was able to fix the problem by stripping the `file:` prefix from the URI

With fix:

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/4b915d75-51c8-4384-9bf8-e015346c333a" />


