### PR TITLE
fix(cfn_lint): Fix cfn-lint arg for stdin

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -3,7 +3,6 @@
 ## General
 
 - Before committing, please go through the following steps:
-
   1. Lint Lua files with [selene](https://github.com/Kampfkarren/selene)
   2. Format Lua files with [StyLua](https://github.com/JohnnyMorganz/StyLua)
   3. If you've updated documentation, format Markdown files with
@@ -116,7 +115,6 @@ local diagnostic = {
 - If your source can produce project-level diagnostics (i.e. diagnostics for
   more than one file at a time), use the `multiple_files` option described in
   [HELPERS](./HELPERS.md).
-
   - Specify that your source supports project diagnostics in its documentation.
 
   - Make sure each multi-file diagnostic includes either a `filename` or a

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 ## General
 
 - Before committing, please go through the following steps:
+
   1. Lint Lua files with [selene](https://github.com/Kampfkarren/selene)
   2. Format Lua files with [StyLua](https://github.com/JohnnyMorganz/StyLua)
   3. If you've updated documentation, format Markdown files with
@@ -115,6 +116,7 @@ local diagnostic = {
 - If your source can produce project-level diagnostics (i.e. diagnostics for
   more than one file at a time), use the `multiple_files` option described in
   [HELPERS](./HELPERS.md).
+
   - Specify that your source supports project diagnostics in its documentation.
 
   - Make sure each multi-file diagnostic includes either a `filename` or a

--- a/lua/null-ls/builtins/diagnostics/cfn_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/cfn_lint.lua
@@ -22,7 +22,7 @@ return h.make_builtin({
     filetypes = { "yaml", "json" },
     generator_opts = {
         command = "cfn-lint",
-        args = { "--format", "parseable", "-" },
+        args = { "--format", "parseable" },
         to_stdin = true,
         from_stderr = true,
         format = "line",


### PR DESCRIPTION
cfn-lint is broken if you pass "-" as a filename for stdin, but understands receiving no filenames (and stdin not being a tty) as meaning it should use stdin as the source.

Tested with cfn-lint 1.38.0.