### PR TITLE
chore: Update Trivy Diagnostics

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1779,7 +1779,7 @@ local sources = { null_ls.builtins.diagnostics.trivy }
 
 #### Defaults
 
-- Filetypes: `{ "terraform", "tf", "terraform-vars" }`
+- Filetypes: `{ "terraform", "tf", "terraform-vars", "helmfile", "dockerfile" }`
 - Method: `diagnostics_on_save`
 - Command: `trivy`
 - Args: dynamically resolved (see [source](https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/trivy.lua))

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -3,7 +3,6 @@
 ## General
 
 - Before committing, please go through the following steps:
-
   1. Lint Lua files with [selene](https://github.com/Kampfkarren/selene)
   2. Format Lua files with [StyLua](https://github.com/JohnnyMorganz/StyLua)
   3. If you've updated documentation, format Markdown files with
@@ -116,7 +115,6 @@ local diagnostic = {
 - If your source can produce project-level diagnostics (i.e. diagnostics for
   more than one file at a time), use the `multiple_files` option described in
   [HELPERS](./HELPERS.md).
-
   - Specify that your source supports project diagnostics in its documentation.
 
   - Make sure each multi-file diagnostic includes either a `filename` or a

--- a/doc/builtins.json
+++ b/doc/builtins.json
@@ -499,7 +499,9 @@
       "filetypes": [
         "terraform",
         "tf",
-        "terraform-vars"
+        "terraform-vars",
+        "helmfile",
+        "dockerfile"
       ]
     },
     "twigcs": {

--- a/lua/null-ls/builtins/_meta/diagnostics.lua
+++ b/lua/null-ls/builtins/_meta/diagnostics.lua
@@ -242,7 +242,7 @@ return {
     filetypes = {}
   },
   trivy = {
-    filetypes = { "terraform", "tf", "terraform-vars" }
+    filetypes = { "terraform", "tf", "terraform-vars", "helm", "dockerfile" }
   },
   twigcs = {
     filetypes = { "twig" }

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -207,6 +207,9 @@ return {
     diagnostics = { "terragrunt_validate" },
     formatting = { "atlas_fmt", "hclfmt", "packer", "terragrunt_fmt" }
   },
+  helm = {
+    diagnostics = { "trivy" }
+  },
   html = {
     diagnostics = { "markuplint", "tidy" },
     formatting = { "prettier", "prettierd", "rustywind", "tidy" }
@@ -494,7 +497,7 @@ return {
     formatting = { "tidy", "xmllint" }
   },
   yaml = {
-    diagnostics = { "actionlint", "cfn_lint", "spectral", "vacuum", "yamllint" },
+    diagnostics = { "actionlint", "cfn_lint", "spectral", "vacuum", "yamllint", "trivy" },
     formatting = { "prettier", "prettierd", "yamlfix", "yamlfmt" }
   },
   ["yaml.ansible"] = {

--- a/lua/null-ls/builtins/diagnostics/trivy.lua
+++ b/lua/null-ls/builtins/diagnostics/trivy.lua
@@ -102,7 +102,8 @@ return h.make_builtin({
             for _, result in pairs(params.output.Results or {}) do
                 for _, misconfiguration in ipairs(result.Misconfigurations or {}) do
                     local rewritten_diagnostic = {
-                        message = misconfiguration.ID .. " - " .. misconfiguration.Title,
+                        code = misconfiguration.ID,
+                        message =  misconfiguration.Title,
                         row = misconfiguration.CauseMetadata.StartLine,
                         end_row = misconfiguration.CauseMetadata.EndLine,
                         col = 0,

--- a/lua/null-ls/builtins/diagnostics/trivy.lua
+++ b/lua/null-ls/builtins/diagnostics/trivy.lua
@@ -103,7 +103,7 @@ return h.make_builtin({
                 for _, misconfiguration in ipairs(result.Misconfigurations or {}) do
                     local rewritten_diagnostic = {
                         code = misconfiguration.ID,
-                        message =  misconfiguration.Title,
+                        message = misconfiguration.Title,
                         row = misconfiguration.CauseMetadata.StartLine,
                         end_row = misconfiguration.CauseMetadata.EndLine,
                         col = 0,


### PR DESCRIPTION
- Added new filetypes:
  - `helm` - Helm files.
  - `dockerfile` - Dockerfiles.
- Adapt diagnostics to parse from 'stderr' (https://github.com/aquasecurity/trivy/pull/2289)
- Update message structure to include trivy misconfiguration ID as diagnostic `code`.
