### PR TITLE
fix(diagnostics): fix markdownlint-cli2 failing

### DIFF
--- a/lua/null-ls/builtins/diagnostics/markdownlint_cli2.lua
+++ b/lua/null-ls/builtins/diagnostics/markdownlint_cli2.lua
@@ -17,6 +17,7 @@ return h.make_builtin({
     filetypes = { "markdown" },
     generator_opts = {
         command = "markdownlint-cli2",
+        args = { "$FILENAME" },
         from_stderr = true,
         format = "line",
         multiple_files = true,


### PR DESCRIPTION
markdownlint_cli2 prints usage and exits when no targets are specified.

<details>
<summary>debug log</summary>

```
[DEBUG Sat 26 Jul 2025 05:08:29 PM JST] /home/me/.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/helpers/generator_factory.lua:359: spawning command "markdownlint-cli2" at /home/me/Documents/notes with args {}
[TRACE Sat 26 Jul 2025 05:08:29 PM JST] /home/me/.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/helpers/generator_factory.lua:240: error output: markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
https://github.com/DavidAnson/markdownlint-cli2

Syntax: markdownlint-cli2 glob0 [glob1] [...] [globN] [--config file] [--fix] [--help]

Glob expressions (from the globby library):
- * matches any number of characters, but not /
- ? matches a single character, but not /
- ** matches any number of characters, including /
- {} allows for a comma-separated list of "or" expressions
- ! or # at the beginning of a pattern negate the match
- : at the beginning identifies a literal file path
- - as a glob represents standard input (stdin)

Dot-only glob:
- The command "markdownlint-cli2 ." would lint every file in the current directory tree which is probably not intended
- Instead, it is mapped to "markdownlint-cli2 *.{md,markdown}" which lints all Markdown files in the current directory
- To lint every file in the current directory tree, the command "markdownlint-cli2 **" can be used instead

Optional parameters:
- --config    specifies the path to a configuration file to define the base configuration
- --fix       updates files to resolve fixable issues (can be overridden in configuration)
- --help      writes this message to the console and exits without doing anything else
- --no-globs  ignores the "globs" property if present in the top-level options object

Configuration via:
- .markdownlint-cli2.jsonc
- .markdownlint-cli2.yaml
- .markdownlint-cli2.cjs or .markdownlint-cli2.mjs
- .markdownlint.jsonc or .markdownlint.json
- .markdownlint.yaml or .markdownlint.yml
- .markdownlint.cjs or .markdownlint.mjs
- package.json

Cross-platform compatibility:
- UNIX and Windows shells expand globs according to different rules; quoting arguments is recommended
- Some Windows shells don't handle single-quoted (') arguments well; double-quote (") is recommended
- Shells that expand globs do not support negated patterns (!node_modules); quoting is required here
- Some UNIX shells parse exclamation (!) in double-quotes; hashtag (#) is recommended in these cases
- The path separator is forward slash (/) on all platforms; backslash (\) is automatically converted
- On any platform, passing the parameter "--" causes all remaining parameters to be treated literally

The most compatible syntax for cross-platform support:
$ markdownlint-cli2 "**/*.md" "#node_modules"

[TRACE Sat 26 Jul 2025 05:08:29 PM JST] /home/me/.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/helpers/generator_factory.lua:241: output: nil
[TRACE Sat 26 Jul 2025 05:08:29 PM JST] /home/me/.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/diagnostics.lua:185: received diagnostics from source 6
[TRACE Sat 26 Jul 2025 05:08:29 PM JST] /home/me/.local/share/nvim/lazy/none-ls.nvim/lua/null-ls/diagnostics.lua:186: {}
```

</details>
