### PR TITLE
fix(bean_format): fix bean_format for beancount v3

### DIFF
--- a/lua/null-ls/builtins/formatting/bean_format.lua
+++ b/lua/null-ls/builtins/formatting/bean_format.lua
@@ -17,6 +17,7 @@ return h.make_builtin({
     filetypes = { "beancount" },
     generator_opts = {
         command = "bean-format",
+        args = { "-" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
`bean-format` from beancount v3 requires '-' argument to read from stdin.
beancount v2 works both ways.

```
$ bean-format --version
Beancount 3.1.0

$ bean-format <ledger.beancount
Usage: bean-format [OPTIONS] FILENAME
Try 'bean-format --help' for help.

Error: Missing argument 'FILENAME'.
```

With '-' both version works:

```
$ bean-format --version
Beancount 2.3.6
$ bean-format - <ledger.beancount
;; -*- mode: org; mode: beancount; -*-
...

$ bean-format --version
Beancount 3.1.0
$ bean-format - <ledger.beancount
;; -*- mode: org; mode: beancount; -*-
...
```
