### PR TITLE
fix(forge_fmt): cwd to the first parent with the foundry.toml file

### DIFF
--- a/lua/null-ls/builtins/formatting/forge_fmt.lua
+++ b/lua/null-ls/builtins/formatting/forge_fmt.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -17,6 +18,9 @@ return h.make_builtin({
             "fmt",
             "$FILENAME",
         },
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern("foundry.toml")(params.bufname)
+        end),
         to_stdin = false,
         to_temp_file = true,
     },


### PR DESCRIPTION
If a foundry/forge project is not in the $ROOT path (e.g. /repo/contracts-project), the `forge` command runs without loading the configuration from the `foundry.toml` file, unless a `--root PATH` is passed as argument. 

This happens even if you open the `/repo/contracts-project` folder directly, because `$ROOT` is still set to `/repo` if `/repo/.git` exists.

This PR adds a dynamic cached `cwd` for the `forge_fmt` formatter so that each buffer runs from the foundry project root.