### PR TITLE
feat(vsg): adds formatter and diagnostics for vhdl-style-guide (VSG)

### DIFF
--- a/lua/null-ls/builtins/diagnostics/vsg.lua
+++ b/lua/null-ls/builtins/diagnostics/vsg.lua
@@ -1,0 +1,61 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    name = "vsg",
+    meta = {
+        url = "https://github.com/jeremiah-c-leary/vhdl-style-guide",
+        description = "VHDL Style guide is a tool for linting for fixing styple in VHDL files",
+        config = {
+            {
+                key = "config_file_name",
+                type = "string",
+                description = "Name of the VSG config file to use. If this file is present in the root, it will be passed to vsg with the `-c` option",
+                usage = "vsg_config.yaml",
+            },
+        },
+    },
+    method = DIAGNOSTICS,
+    filetypes = { "vhdl" },
+    generator_opts = {
+        command = "vsg",
+        args = function(params)
+            local rv = {}
+            local config_file_name = params:get_config().config_file_name
+            -- check if there is a config file in the root directory, if so
+            -- insert the -c argument with it
+            if config_file_name and vim.fn.filereadable(params.root .. "/" .. config_file_name) == 1 then
+                table.insert(rv, "-c=" .. params.root .. "/" .. config_file_name)
+            end
+            table.insert(rv, "--stdin")
+            table.insert(rv, "-of=syntastic")
+            return rv
+        end,
+        cwd = nil,
+        check_exit_code = function()
+            return true
+        end,
+        from_stderr = false,
+        ignore_stderr = true,
+        to_stdin = true,
+        format = "line",
+        multiple_files = false,
+        on_output = h.diagnostics.from_patterns({
+            {
+                pattern = [[(%w+).*%((%d+)%)(.*)%s+%-%-%s+(.*)]],
+                groups = { "severity", "row", "code", "message" },
+                overrides = {
+                    severities = {
+                        ["ERROR"] = 2,
+                        ["WARNING"] = 3,
+                        ["INFORMATION"] = 3,
+                        ["HINT"] = 4,
+                    },
+                },
+            },
+        }),
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/formatting/vsg.lua
+++ b/lua/null-ls/builtins/formatting/vsg.lua
@@ -1,0 +1,46 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "VSG Formatting",
+    meta = {
+        url = "https://github.com/jeremiah-c-leary/vhdl-style-guide",
+        description = "VHDL Style guide is a tool for linting for fixing styple in VHDL files",
+        config = {
+            {
+                key = "config_file_name",
+                type = "string",
+                description = "Name of the VSG config file to use. If this file is present in the root, it will be passed to vsg with the `-c` option",
+                usage = "vsg_config.yaml",
+            },
+        },
+    },
+    method = FORMATTING,
+    filetypes = { "vhdl" },
+    generator_opts = {
+        command = "vsg",
+        args = function(params)
+            local rv = {}
+            local config_file_name = params:get_config().config_file_name
+            -- check if there is a config file in the root directory, if so
+            -- insert the -c argument with it
+            if config_file_name and vim.fn.filereadable(params.root .. "/" .. config_file_name) == 1 then
+                table.insert(rv, "-c=" .. params.root .. "/" .. config_file_name)
+            end
+            table.insert(rv, "-of=syntastic")
+            table.insert(rv, "-f=$FILENAME")
+            table.insert(rv, "--fix")
+            return rv
+        end,
+        cwd = nil,
+        check_exit_code = { 0, 1 },
+        ignore_stderr = true,
+        to_temp_file = true,
+        from_temp_file = true,
+        to_stdin = false,
+        multiple_files = false,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
adds a diagnostics parser and formatter for the tool VHDL-Style-Guide (https://github.com/jeremiah-c-leary/vhdl-style-guide) (VSG) which is a style checker/fixer for VHDL

## What does this PR do?

adds a diagnostics parser and formatter for the tool VHDL-Style-Guide (https://github.com/jeremiah-c-leary/vhdl-style-guide) (VSG) which is a style checker/fixer for VHDL

I have been using a custom factory for both of these (or similar enough), which has resided in my [`dotfiles`](https://github.com/SethGower/dotfiles/blob/main/config/nvim/lua/plugins/lsp.lua#L107) for a few years now. I figured I would contribute it upstream.

## Checklist

- [x] If I'm adding a new builtin (linter, formatter, code action, etc.), I
      understand it should be contributed to
      [nvimtools/none-ls-extras.nvim](https://github.com/nvimtools/none-ls-extras.nvim)
      instead
- [ ] I've written tests for these changes
