### PR TITLE
fix(nix_flake_fmt): format from subdirectories of a flake

### DIFF
--- a/lua/null-ls/builtins/formatting/nix_flake_fmt.lua
+++ b/lua/null-ls/builtins/formatting/nix_flake_fmt.lua
@@ -340,8 +340,8 @@ return h.make_builtin({
         },
         to_temp_file = true,
     },
-    condition = function(utils)
-        return utils.root_has_file("flake.nix")
+    condition = function(_)
+        return vim.fs.root(".", "flake.nix") ~= nil
     end,
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
## What does this PR do?

Allows to use nix_flake_fmt from child directories of a nix flake
