### PR TITLE
fix(builtins/diagnostics/vacuum): crash on malformed file

### DIFF
--- a/lua/null-ls/builtins/diagnostics/vacuum.lua
+++ b/lua/null-ls/builtins/diagnostics/vacuum.lua
@@ -27,7 +27,7 @@ return h.make_builtin({
         end,
         on_output = function(params)
             local diags = {}
-            if params.output.resultSet.results == vim.NIL then
+            if params.output.resultSet.results == vim.NIL or params.output.resultSet.results == nil then
                 return diags
             end
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a crash in none-ls' vacuum diagnostics when vacuum returns a `resultSet` without a `results` field (e.g. on malformed OpenAPI input).

I discovered this bug while I was editing an openapi document, none-ls would crash randomly with the following error:

```
[null-ls] failed to run generator: ...none-ls.nvim/lua/null-ls/builtins/diagnostics/vacuum.lua:34: bad argument #1 to 'ipairs' (table expected, got nil)
```

At first I was puzzled, but later I started to notice it only happens when the file is malformed (e.g. when I was pasting a line with improper indentation).

I thought of exploring the referenced file, and saw this:

https://github.com/nvimtools/none-ls.nvim/blob/1fcf9cbf9acf893455c6cee792537aa709de62cb/lua/null-ls/builtins/diagnostics/vacuum.lua#L28-L37

I appended a new expression that checks whether `params.output.resultSet.results == nil` like such:

```lua
if params.output.resultSet.results == vim.NIL or params.output.resultSet.results == nil then
    return diags
end
```

And somehow it started working like normal... so yeah.

After some bit of digging, I found that the commit https://github.com/nvimtools/none-ls.nvim/commit/ba068296f3c98749c838a78b18c9e197f642a7af introduced the if-statement. So I decided to test running `vacuum`'s report command and compared the output for the older version (of the commit) to the latest version.

This is the old version:

```console
$ # Older version of vacuum at the time of commit (Mar 20, 2023)
$ echo "openapi: 3.0.1" | go run github.com/daveshanley/vacuum@v0.0.53 report -i -o | jq .resultSet
{
  "results": [
    ...
  ],
  "warningCount": 0,
  "errorCount": 2,
  "infoCount": 0
}

$ echo "broken-file" | go run github.com/daveshanley/vacuum@v0.0.53 report -i -o | jq .resultSet
{
  "results": null,
  "warningCount": 0,
  "errorCount": 0,
  "infoCount": 0
}
```

This is the latest version:

```console
$ # Newer version of vacuum
$ echo "openapi: 3.0.1" | go run github.com/daveshanley/vacuum@latest report -i -o | jq .resultSet
{
  "results": [
    ...
  ],
  "warningCount": 1,
  "errorCount": 1,
  "infoCount": 0
}

$ echo "broken-file" | go run github.com/daveshanley/vacuum@latest report -i -o | jq .resultSet
{
  "warningCount": 0,
  "errorCount": 0,
  "infoCount": 0
}
```

As you can tell it was `null` back then but now the `results` key does not exist anymore. So this is the primary cause of the problem.