### PR TITLE
fix: use new 3-arg API for vim.str_utfindex

### DIFF
--- a/lua/null-ls/diff.lua
+++ b/lua/null-ls/diff.lua
@@ -155,8 +155,8 @@ function M.compute_diff(old_lines, new_lines, line_ending)
         adj_end_char = #old_lines[#old_lines + end_line + 1] + end_char + 1
     end
 
-    local _, adjusted_start_char = vim.str_utfindex(old_lines[start_line], start_char - 1)
-    local _, adjusted_end_char = vim.str_utfindex(old_lines[#old_lines + end_line + 1], adj_end_char)
+    local adjusted_start_char = vim.str_utfindex(old_lines[start_line], "utf-16", start_char - 1)
+    local adjusted_end_char = vim.str_utfindex(old_lines[#old_lines + end_line + 1], "utf-16", adj_end_char)
     start_char = adjusted_start_char
     end_char = adjusted_end_char
 


### PR DESCRIPTION
## What does this PR do?

Replace deprecated 2-arg `vim.str_utfindex(s, index)` with the new 3-arg `vim.str_utfindex(s, "utf-16", index)` API.

The old API returns `utf-32, utf-16` — the code uses the second `utf-16` value, so the new encoding-explicit call is equivalent.

This fixes deprecation warning on Neovim 0.12+: `vim.str_utfindex is deprecated. Feature will be removed in Nvim 1.0`.
