### PR TITLE
fix(todo_comments): handle nil parser from get_parser on nvim 0.12

### DIFF
--- a/lua/null-ls/builtins/diagnostics/todo_comments.lua
+++ b/lua/null-ls/builtins/diagnostics/todo_comments.lua
@@ -18,8 +18,10 @@ local function get_document_root(bufnr, filetype)
         return
     end
 
-    local has_parser, parser = pcall(vim.treesitter.get_parser, bufnr, lang)
-    if not has_parser then
+    -- `error = false` is only needed for nvim 0.11; on 0.12+ get_parser never
+    -- throws and returns nil when no parser is available.
+    local parser = vim.treesitter.get_parser(bufnr, lang, { error = false })
+    if not parser then
         log:debug("no parser available for lang " .. lang)
         return
     end


### PR DESCRIPTION
## What does this PR do?

Since neovim/neovim#37276 (released in 0.12), `vim.treesitter.get_parser()` returns `nil` instead of throwing when no parser is installed for the language. The `pcall` in `todo_comments` therefore succeeds with `parser == nil`, and the subsequent `parser:parse()` errors with

```
attempt to index local 'parser' (a nil value)
```

on any buffer whose filetype has no treesitter grammar installed.

This PR makes the existing guard also bail out when `parser` is `nil`.

## Checklist

- [x] If I'm adding a new builtin (linter, formatter, code action, etc.), I
      understand it should be contributed to
      [nvimtools/none-ls-extras.nvim](https://github.com/nvimtools/none-ls-extras.nvim)
      instead — N/A, bugfix to existing builtin
- [ ] I've written tests for these changes — one-line nil guard, no test infra for this builtin
