### PR TITLE
fix: tolerate strict index conversion on nvim 0.12+

### DIFF
--- a/lua/null-ls/diff.lua
+++ b/lua/null-ls/diff.lua
@@ -155,8 +155,8 @@ function M.compute_diff(old_lines, new_lines, line_ending)
         adj_end_char = #old_lines[#old_lines + end_line + 1] + end_char + 1
     end
 
-    local adjusted_start_char = vim.str_utfindex(old_lines[start_line], "utf-16", start_char - 1)
-    local adjusted_end_char = vim.str_utfindex(old_lines[#old_lines + end_line + 1], "utf-16", adj_end_char)
+    local adjusted_start_char = vim.str_utfindex(old_lines[start_line], "utf-16", start_char - 1, false)
+    local adjusted_end_char = vim.str_utfindex(old_lines[#old_lines + end_line + 1], "utf-16", adj_end_char, false)
     start_char = adjusted_start_char
     end_char = adjusted_end_char
 

--- a/lua/null-ls/helpers/diagnostics.lua
+++ b/lua/null-ls/helpers/diagnostics.lua
@@ -70,11 +70,11 @@ local make_diagnostic = function(entries, defaults, attr_adapters, params, offse
     -- and https://github.com/nvimtools/none-ls.nvim/issues/226
     if entries["col"] ~= nil and content_line ~= nil then
         local col = tonumber(entries["col"]) or math.huge
-        col = math.min(col, vim.fn.strwidth(content_line))
+        col = math.min(col, vim.fn.strchars(content_line))
 
         local byte_index_col
         if u.has_version("0.11") then
-            byte_index_col = vim.str_byteindex(content_line, "utf-32", col)
+            byte_index_col = vim.str_byteindex(content_line, "utf-32", col, false)
         else
             byte_index_col = vim.str_byteindex(content_line, col)
         end


### PR DESCRIPTION
## What does this PR do?

Neovim 0.12 made vim.str_byteindex / vim.str_utfindex strict by default and they now raise "index out of range" when the index exceeds the string, where older versions silently clamped.