### PR TITLE
feat(formatting): Add json5 filetype to prettier and prettierd

### DIFF
--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -28,6 +28,7 @@ return h.make_builtin({
         "less",
         "html",
         "json",
+        "json5",
         "jsonc",
         "yaml",
         "markdown",

--- a/lua/null-ls/builtins/formatting/prettierd.lua
+++ b/lua/null-ls/builtins/formatting/prettierd.lua
@@ -24,6 +24,7 @@ return h.make_builtin({
         "less",
         "html",
         "json",
+        "json5",
         "jsonc",
         "yaml",
         "markdown",


### PR DESCRIPTION
## What does this PR do?

Adding the `json5` filetype to the `prettier`/`prettierd` builtins.

Prettier has a `json5` parser as seen [here](https://prettier.io/docs/options#parser:~:text=available%20in%20v1.5.0-,%22json5%22).

I tested adding `json5` to `extra_filetypes` and it worked fine.

## Checklist

- [X] If I'm adding a new builtin (linter, formatter, code action, etc.), I
      understand it should be contributed to
      [nvimtools/none-ls-extras.nvim](https://github.com/nvimtools/none-ls-extras.nvim)
      instead
- [ ] I've written tests for these changes
